### PR TITLE
Use different -Map argument for Clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ override CFLAGS += -mthumb-interwork -Wimplicit -Wparentheses -Werror -O2 -fhex-
 CPPFLAGS := -I tools/agbcc -I tools/agbcc/include -iquote include -nostdinc -undef
 
 # LLVM requires a different syntax for generating the map file.
+# We also keep the old LDFLAGS variable, before changing it, since the tools don't need the -Map argument.
+ORIG_LD := $(LDFLAGS)
 IS_LLVM = $(shell $(CXX) --help | grep -i "clang llvm compiler")
 LLVM_LDFLAGS = -Wl,-map,../../$(MAP)
 GCC_LDFLAGS = -Map ../../$(MAP)
@@ -89,16 +91,16 @@ all: rom
 rom: tools $(ROM)
 
 tools:
-	@$(MAKE) -C tools/gbagfx
-	@$(MAKE) -C tools/scaninc
-	@$(MAKE) -C tools/preproc
-	@$(MAKE) -C tools/bin2c
-	@$(MAKE) -C tools/rsfont
-	@$(MAKE) -C tools/aif2pcm
-	@$(MAKE) -C tools/ramscrgen
-	@$(MAKE) -C tools/mid2agb
-	@$(MAKE) -C tools/gbafix
-	@$(MAKE) -C tools/mapjson
+	@$(MAKE) -C tools/gbagfx LDFLAGS=$(ORIG_LD)
+	@$(MAKE) -C tools/scaninc LDFLAGS=$(ORIG_LD)
+	@$(MAKE) -C tools/preproc LDFLAGS=$(ORIG_LD)
+	@$(MAKE) -C tools/bin2c LDFLAGS=$(ORIG_LD)
+	@$(MAKE) -C tools/rsfont LDFLAGS=$(ORIG_LD)
+	@$(MAKE) -C tools/aif2pcm LDFLAGS=$(ORIG_LD)
+	@$(MAKE) -C tools/ramscrgen LDFLAGS=$(ORIG_LD)
+	@$(MAKE) -C tools/mid2agb LDFLAGS=$(ORIG_LD)
+	@$(MAKE) -C tools/gbafix LDFLAGS=$(ORIG_LD)
+	@$(MAKE) -C tools/mapjson LDFLAGS=$(ORIG_LD)
 
 # For contributors to make sure a change didn't affect the contents of the ROM.
 compare: rom

--- a/berry_fix/Makefile
+++ b/berry_fix/Makefile
@@ -153,7 +153,7 @@ $(SONG_BUILDDIR)/%.o: $(SONG_SUBDIR)/%.s
 	$(AS) $(ASFLAGS) -I sound -o $@ $<
 
 $(ELF): ld_script.txt $(OBJS)
-	cd $(OBJ_DIR) && ../$(LD) $(LDFLAGS) -T ../ld_script.txt -o ../$@
+	cd $(OBJ_DIR) && ../$(LD) $(GCC_LDFLAGS) -T ../ld_script.txt -o ../$@
 
 $(ROM): $(ELF)
 	$(OBJCOPY) -O binary $< $@

--- a/berry_fix/payload/Makefile
+++ b/berry_fix/payload/Makefile
@@ -159,7 +159,7 @@ $(OBJ_DIR)/ld_script.ld: ld_script.txt $(OBJ_DIR)/sym_bss.ld $(OBJ_DIR)/sym_comm
 	cd $(OBJ_DIR) && sed -f ../../ld_script.sed ../$< | sed "s#tools/#../tools/#g" > ld_script.ld
 
 $(ELF): $(OBJ_DIR)/ld_script.ld $(OBJS)
-	cd $(OBJ_DIR) && ../$(LD) $(LDFLAGS) -T ld_script.ld -o ../$@ $(LIB)
+	cd $(OBJ_DIR) && ../$(LD) $(GCC_LDFLAGS) -T ld_script.ld -o ../$@ $(LIB)
 
 $(ROM): $(ELF)
 	$(OBJCOPY) -O binary $< $@


### PR DESCRIPTION
Hi there. I just attempted to build the ROM for the first time on Mac OS X, but I found that it ran into a problem while building the tools. Specifically `mid2agb`. Its makefile errors out here:

```
gcc -Wall -Wextra -Werror -Wno-sign-compare -std=c11 -O2 -DPNG_SKIP_SETJMP_CHECK main.c convert_png.c gfx.c jasc_pal.c lz.c rl.c util.c font.c huff.c -o gbagfx -Map ../../pokefirered.map -lpng -lz
clang: error: unknown argument: '-Map'
clang: error: no such file or directory: '../../pokefirered.map'
```

On OSX, `gcc` and `g++` are linked to Clang, which requires a different syntax. This PR checks whether Clang is the compiler and sets the appropriate syntax. It also changes a few other commands to explicitly use the GCC version, since they use the `arm-none-eabi-ld` linker explicitly.

**Question:** when running `./build_tools.sh`, the tools makefiles are executed without going through the main makefile first, meaning the `LDFLAGS` will be different. I assume that the build tools don't need the `-Map` argument at all, so in the main makefile I've made sure the tools makefiles get executed with the original variable. I'm not 100% sure if this is correct so let me know - it does compile with successful compare now though.