### PR TITLE
hidemoneybox buries dummy args now

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1014,8 +1014,10 @@
 	.endm
 
 	@ Hides the secondary box spawned by showmoney.
-	.macro hidemoneybox
+	.macro hidemoneybox @, x, y
 	.byte 0x94
+	.byte 0 @ x
+	.byte 0 @ y
 	.endm
 
 	@ Updates the secondary box spawned by showmoney. Consumes but does not use arguments.

--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -1014,10 +1014,12 @@
 	.endm
 
 	@ Hides the secondary box spawned by showmoney.
-	.macro hidemoneybox @, x, y
+	@ The two arguments are unused.
+	@ They are retained here for backwards compatibility with Ruby/Sapphire.
+	.macro hidemoneybox x, y
 	.byte 0x94
-	.byte 0 @ x
-	.byte 0 @ y
+	.byte \x
+	.byte \y
 	.endm
 
 	@ Updates the secondary box spawned by showmoney. Consumes but does not use arguments.

--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -7923,23 +7923,17 @@ EventScript_1B2907:: @ 81B2907
 	special Special_UpdateTrainerCardPhotoIcons
 	msgbox gUnknown_81B1E7D
 	hidemoneybox
-	nop
-	nop
 	releaseall
 	end
 
 EventScript_1B2926:: @ 81B2926
 	hidemoneybox
-	nop
-	nop
 	releaseall
 	end
 
 EventScript_1B292B:: @ 81B292B
 	msgbox gUnknown_81B1E07
 	hidemoneybox
-	nop
-	nop
 	releaseall
 	end
 
@@ -11488,8 +11482,6 @@ EventScript_1BF3DD:: @ 81BF3DD
 	msgbox Text_19DDBE
 	fadescreen 1
 	hidemoneybox
-	nop
-	nop
 	special ChooseSendDaycareMon
 	waitstate
 	showmoneybox 0, 0, 0
@@ -11584,8 +11576,6 @@ EventScript_1BF533:: @ 81BF533
 
 EventScript_1BF541:: @ 81BF541
 	hidemoneybox
-	nop
-	nop
 	release
 	end
 

--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -7922,18 +7922,18 @@ EventScript_1B2907:: @ 81B2907
 	delay 60
 	special Special_UpdateTrainerCardPhotoIcons
 	msgbox gUnknown_81B1E7D
-	hidemoneybox
+	hidemoneybox 0, 0
 	releaseall
 	end
 
 EventScript_1B2926:: @ 81B2926
-	hidemoneybox
+	hidemoneybox 0, 0
 	releaseall
 	end
 
 EventScript_1B292B:: @ 81B292B
 	msgbox gUnknown_81B1E07
-	hidemoneybox
+	hidemoneybox 0, 0
 	releaseall
 	end
 
@@ -11481,7 +11481,7 @@ EventScript_1BF3DD:: @ 81BF3DD
 	goto_if eq, EventScript_1BF452
 	msgbox Text_19DDBE
 	fadescreen 1
-	hidemoneybox
+	hidemoneybox 0, 0
 	special ChooseSendDaycareMon
 	waitstate
 	showmoneybox 0, 0, 0
@@ -11575,7 +11575,7 @@ EventScript_1BF533:: @ 81BF533
 	end
 
 EventScript_1BF541:: @ 81BF541
-	hidemoneybox
+	hidemoneybox 0, 0
 	release
 	end
 

--- a/data/maps/CeladonCity_DepartmentStore_Roof/scripts.inc
+++ b/data/maps/CeladonCity_DepartmentStore_Roof/scripts.inc
@@ -297,6 +297,6 @@ EventScript_16C13F:: @ 816C13F
 	end
 
 EventScript_16C14D:: @ 816C14D
-	hidemoneybox
+	hidemoneybox 0, 0
 	releaseall
 	end

--- a/data/maps/CeladonCity_DepartmentStore_Roof/scripts.inc
+++ b/data/maps/CeladonCity_DepartmentStore_Roof/scripts.inc
@@ -298,7 +298,5 @@ EventScript_16C13F:: @ 816C13F
 
 EventScript_16C14D:: @ 816C14D
 	hidemoneybox
-	.byte 0
-	.byte 0
 	releaseall
 	end

--- a/data/maps/CeladonCity_GameCorner/scripts.inc
+++ b/data/maps/CeladonCity_GameCorner/scripts.inc
@@ -80,7 +80,7 @@ EventScript_16C762:: @ 816C762
 	end
 
 EventScript_16C77A:: @ 816C77A
-	hidemoneybox
+	hidemoneybox 0, 0
 	hidecoinsbox 0, 5
 	release
 	end

--- a/data/maps/CeladonCity_GameCorner/scripts.inc
+++ b/data/maps/CeladonCity_GameCorner/scripts.inc
@@ -81,8 +81,6 @@ EventScript_16C762:: @ 816C762
 
 EventScript_16C77A:: @ 816C77A
 	hidemoneybox
-	.byte 0
-	.byte 0
 	hidecoinsbox 0, 5
 	release
 	end

--- a/data/maps/CeruleanCity_BikeShop/scripts.inc
+++ b/data/maps/CeruleanCity_BikeShop/scripts.inc
@@ -26,8 +26,6 @@ EventScript_16AC07:: @ 816AC07
 EventScript_16AC15:: @ 816AC15
 	msgbox gUnknown_819280E
 	hidemoneybox
-	.byte 0
-	.byte 0
 	release
 	end
 

--- a/data/maps/CeruleanCity_BikeShop/scripts.inc
+++ b/data/maps/CeruleanCity_BikeShop/scripts.inc
@@ -25,7 +25,7 @@ EventScript_16AC07:: @ 816AC07
 
 EventScript_16AC15:: @ 816AC15
 	msgbox gUnknown_819280E
-	hidemoneybox
+	hidemoneybox 0, 0
 	release
 	end
 

--- a/data/maps/FuchsiaCity_SafariZone_Entrance/scripts.inc
+++ b/data/maps/FuchsiaCity_SafariZone_Entrance/scripts.inc
@@ -123,7 +123,7 @@ EventScript_16D3CA:: @ 816D3CA
 	call EventScript_1A6675
 	msgbox gUnknown_8197D80
 	closemessage
-	hidemoneybox
+	hidemoneybox 0, 0
 	compare_var_to_value VAR_0x4002, 0
 	call_if eq, EventScript_16D44C
 	compare_var_to_value VAR_0x4002, 1
@@ -169,7 +169,7 @@ EventScript_16D48C:: @ 816D48C
 
 EventScript_16D49A:: @ 816D49A
 	closemessage
-	hidemoneybox
+	hidemoneybox 0, 0
 	applymovement 255, Movement_16D4AA
 	waitmovement 0
 	releaseall

--- a/data/maps/FuchsiaCity_SafariZone_Entrance/scripts.inc
+++ b/data/maps/FuchsiaCity_SafariZone_Entrance/scripts.inc
@@ -124,8 +124,6 @@ EventScript_16D3CA:: @ 816D3CA
 	msgbox gUnknown_8197D80
 	closemessage
 	hidemoneybox
-	.byte 0
-	.byte 0
 	compare_var_to_value VAR_0x4002, 0
 	call_if eq, EventScript_16D44C
 	compare_var_to_value VAR_0x4002, 1
@@ -172,8 +170,6 @@ EventScript_16D48C:: @ 816D48C
 EventScript_16D49A:: @ 816D49A
 	closemessage
 	hidemoneybox
-	.byte 0
-	.byte 0
 	applymovement 255, Movement_16D4AA
 	waitmovement 0
 	releaseall

--- a/data/maps/PewterCity_Museum_1F/scripts.inc
+++ b/data/maps/PewterCity_Museum_1F/scripts.inc
@@ -69,8 +69,6 @@ EventScript_16A3D1:: @ 816A3D1
 	msgbox gUnknown_81904F9
 	closemessage
 	hidemoneybox
-	.byte 0
-	.byte 0
 	applymovement 255, Movement_16A48E
 	waitmovement 0
 	releaseall
@@ -94,8 +92,6 @@ EventScript_16A402:: @ 816A402
 	msgbox gUnknown_8190505
 	setvar VAR_MAP_SCENE_PEWTER_CITY_MUSEUM_1F, 1
 	hidemoneybox
-	.byte 0
-	.byte 0
 	releaseall
 	end
 
@@ -118,8 +114,6 @@ EventScript_16A476:: @ 816A476
 	msgbox gUnknown_819051C
 	closemessage
 	hidemoneybox
-	.byte 0
-	.byte 0
 	applymovement 255, Movement_16A48E
 	waitmovement 0
 	releaseall

--- a/data/maps/PewterCity_Museum_1F/scripts.inc
+++ b/data/maps/PewterCity_Museum_1F/scripts.inc
@@ -68,7 +68,7 @@ EventScript_16A3D1:: @ 816A3D1
 	goto_if eq, EventScript_16A402
 	msgbox gUnknown_81904F9
 	closemessage
-	hidemoneybox
+	hidemoneybox 0, 0
 	applymovement 255, Movement_16A48E
 	waitmovement 0
 	releaseall
@@ -91,7 +91,7 @@ EventScript_16A402:: @ 816A402
 	waitse
 	msgbox gUnknown_8190505
 	setvar VAR_MAP_SCENE_PEWTER_CITY_MUSEUM_1F, 1
-	hidemoneybox
+	hidemoneybox 0, 0
 	releaseall
 	end
 
@@ -113,7 +113,7 @@ EventScript_16A46B:: @ 816A46B
 EventScript_16A476:: @ 816A476
 	msgbox gUnknown_819051C
 	closemessage
-	hidemoneybox
+	hidemoneybox 0, 0
 	applymovement 255, Movement_16A48E
 	waitmovement 0
 	releaseall

--- a/data/maps/Route4_PokemonCenter_1F/scripts.inc
+++ b/data/maps/Route4_PokemonCenter_1F/scripts.inc
@@ -66,8 +66,6 @@ EventScript_16F7F6:: @ 816F7F6
 	call EventScript_1A8C27
 	fadescreen 1
 	hidemoneybox
-	.byte 0
-	.byte 0
 	special ChangePokemonNickname
 	waitstate
 	goto EventScript_16F86A
@@ -80,8 +78,6 @@ EventScript_16F822:: @ 816F822
 	goto_if eq, EventScript_16F84B
 	fadescreen 1
 	hidemoneybox
-	.byte 0
-	.byte 0
 	special ChangeBoxPokemonNickname
 	waitstate
 	lock
@@ -101,8 +97,6 @@ EventScript_16F856:: @ 816F856
 
 EventScript_16F861:: @ 816F861
 	hidemoneybox
-	.byte 0
-	.byte 0
 	goto EventScript_16F86A
 	end
 
@@ -124,16 +118,12 @@ EventScript_16F86F:: @ 816F86F
 EventScript_16F888:: @ 816F888
 	msgbox gUnknown_819DC07
 	hidemoneybox
-	.byte 0
-	.byte 0
 	release
 	end
 
 EventScript_16F895:: @ 816F895
 	msgbox gUnknown_819DC78
 	hidemoneybox
-	.byte 0
-	.byte 0
 	release
 	end
 
@@ -146,8 +136,6 @@ EventScript_16F8AC:: @ 816F8AC
 	textcolor 0
 	msgbox gUnknown_819DC3E
 	hidemoneybox
-	.byte 0
-	.byte 0
 	release
 	end
 

--- a/data/maps/Route4_PokemonCenter_1F/scripts.inc
+++ b/data/maps/Route4_PokemonCenter_1F/scripts.inc
@@ -65,7 +65,7 @@ EventScript_16F7F6:: @ 816F7F6
 	goto_if eq, EventScript_16F861
 	call EventScript_1A8C27
 	fadescreen 1
-	hidemoneybox
+	hidemoneybox 0, 0
 	special ChangePokemonNickname
 	waitstate
 	goto EventScript_16F86A
@@ -77,7 +77,7 @@ EventScript_16F822:: @ 816F822
 	compare_var_to_value VAR_RESULT, 0
 	goto_if eq, EventScript_16F84B
 	fadescreen 1
-	hidemoneybox
+	hidemoneybox 0, 0
 	special ChangeBoxPokemonNickname
 	waitstate
 	lock
@@ -96,7 +96,7 @@ EventScript_16F856:: @ 816F856
 	end
 
 EventScript_16F861:: @ 816F861
-	hidemoneybox
+	hidemoneybox 0, 0
 	goto EventScript_16F86A
 	end
 
@@ -117,13 +117,13 @@ EventScript_16F86F:: @ 816F86F
 
 EventScript_16F888:: @ 816F888
 	msgbox gUnknown_819DC07
-	hidemoneybox
+	hidemoneybox 0, 0
 	release
 	end
 
 EventScript_16F895:: @ 816F895
 	msgbox gUnknown_819DC78
-	hidemoneybox
+	hidemoneybox 0, 0
 	release
 	end
 
@@ -135,7 +135,7 @@ EventScript_16F8A2:: @ 816F8A2
 EventScript_16F8AC:: @ 816F8AC
 	textcolor 0
 	msgbox gUnknown_819DC3E
-	hidemoneybox
+	hidemoneybox 0, 0
 	release
 	end
 


### PR DESCRIPTION
Pursuant to a recent discussion in the Emerald discord, it was agreed that the two nops (.byte 0, 0) following every instance of `hidemoneybox` should be hardcoded into the command macro definition.  The command took two one-byte arguments in Ruby and Sapphire but not any of the later titles.  However, these arguments were not properly dummied.