### PR TITLE
 Add VBA's save files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 *.exe
 *.fwjpnfont
 *.gba
+*.sgm
+*.sa1
+*.sg1
 *.gbapal
 *.hwjpnfont
 *.i


### PR DESCRIPTION
Same reasoning I had when I proposed this change to Pokeruby's gitignore.
This format represents VisualBoyAdvance's save files. Since they're currently not being filtered out by .gitignore, these kind of files could be sent to a GitHub Repository via git push accidentally.