### PR TITLE
align directsound samples

### DIFF
--- a/sound/direct_sound_data.inc
+++ b/sound/direct_sound_data.inc
@@ -2,228 +2,303 @@
 DirectSoundWaveData_sc88_glockenspiel::
 	.incbin "sound/direct_sound_samples/sc88_glockenspiel.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_organ2::
 	.incbin "sound/direct_sound_samples/sc88_organ2.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_fretless_bass::
 	.incbin "sound/direct_sound_samples/sc88_fretless_bass.bin"
 
+	.align 2
 DirectSoundWaveData_jv1080_slap_bass::
 	.incbin "sound/direct_sound_samples/jv1080_slap_bass.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_synth_bass::
 	.incbin "sound/direct_sound_samples/sc88_synth_bass.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_timpani::
 	.incbin "sound/direct_sound_samples/sc88_timpani.bin"
 
+	.align 2
 DirectSoundWaveData_classical_choir_voice_ahhs::
 	.incbin "sound/direct_sound_samples/classical_choir_voice_ahhs.bin"
 
+	.align 2
 DirectSoundWaveData_sd90_classical_oboe::
 	.incbin "sound/direct_sound_samples/sd90_classical_oboe.bin"
 
+	.align 2
 DirectSoundWaveData_unused_sd90_oboe::
 	.incbin "sound/direct_sound_samples/unused_sd90_oboe.bin"
 
+	.align 2
 DirectSoundWaveData_unused_electric_guitar::
 	.incbin "sound/direct_sound_samples/unused_electric_guitar.bin"
 
+	.align 2
 DirectSoundWaveData_unused_sc88_unison_slap::
 	.incbin "sound/direct_sound_samples/unused_sc88_unison_slap.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_snare::
 	.incbin "sound/direct_sound_samples/unknown_snare.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_wood_block_low::
 	.incbin "sound/direct_sound_samples/unknown_wood_block_low.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_wood_block_high::
 	.incbin "sound/direct_sound_samples/unknown_wood_block_high.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_standard_kick::
 	.incbin "sound/direct_sound_samples/sc88_standard_kick.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_standard3_snare::
 	.incbin "sound/direct_sound_samples/sc88_standard3_snare.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_standard_hand_clap::
 	.incbin "sound/direct_sound_samples/sc88_standard_hand_clap.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_orchestra_snare::
 	.incbin "sound/direct_sound_samples/sc88_orchestra_snare.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_tambourine::
 	.incbin "sound/direct_sound_samples/unknown_tambourine.bin"
 
+	.align 2
 DirectSoundWaveData_trinity_cymbal_crash::
 	.incbin "sound/direct_sound_samples/trinity_cymbal_crash.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_orchestra_cymbal_crash::
 	.incbin "sound/direct_sound_samples/sc88_orchestra_cymbal_crash.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_bongo::
 	.incbin "sound/direct_sound_samples/sc88_bongo.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_bongo_low::
 	.incbin "sound/direct_sound_samples/sc88_bongo_low.bin"
 
+	.align 2
 DirectSoundWaveData_drum_and_percussion_kick::
 	.incbin "sound/direct_sound_samples/drum_and_percussion_kick.bin"
 
+	.align 2
 DirectSoundWaveData_sd90_solo_snare::
 	.incbin "sound/direct_sound_samples/sd90_solo_snare.bin"
 
+	.align 2
 DirectSoundWaveData_sd90_ambient_tom::
 	.incbin "sound/direct_sound_samples/sd90_ambient_tom.bin"
 
+	.align 2
 DirectSoundWaveData_dance_drums_ride_bell::
 	.incbin "sound/direct_sound_samples/dance_drums_ride_bell.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_cowbell::
 	.incbin "sound/direct_sound_samples/unknown_cowbell.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_djembe::
 	.incbin "sound/direct_sound_samples/unknown_djembe.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_anvil_high::
 	.incbin "sound/direct_sound_samples/unknown_anvil_high.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_standard_bells::
 	.incbin "sound/direct_sound_samples/sc88_standard_bells.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_anvil_low::
 	.incbin "sound/direct_sound_samples/unknown_anvil_low.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_ethnic_drum::
 	.incbin "sound/direct_sound_samples/unknown_ethnic_drum.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_tsuzumi::
 	.incbin "sound/direct_sound_samples/unknown_tsuzumi.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_piano1_48::
 	.incbin "sound/direct_sound_samples/sc88_piano1_48.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_piano1_60::
 	.incbin "sound/direct_sound_samples/sc88_piano1_60.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_piano1_72::
 	.incbin "sound/direct_sound_samples/sc88_piano1_72.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_piano1_84::
 	.incbin "sound/direct_sound_samples/sc88_piano1_84.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_string_ensemble_60::
 	.incbin "sound/direct_sound_samples/sc88_string_ensemble_60.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_string_ensemble_72::
 	.incbin "sound/direct_sound_samples/sc88_string_ensemble_72.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_string_ensemble_84::
 	.incbin "sound/direct_sound_samples/sc88_string_ensemble_84.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_trumpet_60::
 	.incbin "sound/direct_sound_samples/sc88_trumpet_60.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_trumpet_72::
 	.incbin "sound/direct_sound_samples/sc88_trumpet_72.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_trumpet_84::
 	.incbin "sound/direct_sound_samples/sc88_trumpet_84.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_trombone_39::
 	.incbin "sound/direct_sound_samples/unknown_trombone_39.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_trombone_51::
 	.incbin "sound/direct_sound_samples/unknown_trombone_51.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_french_horn_60::
 	.incbin "sound/direct_sound_samples/sc88_french_horn_60.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_french_horn_72::
 	.incbin "sound/direct_sound_samples/sc88_french_horn_72.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_flute::
 	.incbin "sound/direct_sound_samples/sc88_flute.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_pick_bass::
 	.incbin "sound/direct_sound_samples/sc88_pick_bass.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_timpani_with_snare::
 	.incbin "sound/direct_sound_samples/sc88_timpani_with_snare.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_synth_snare::
 	.incbin "sound/direct_sound_samples/unknown_synth_snare.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_square_wave::
 	.incbin "sound/direct_sound_samples/sc88_square_wave.bin"
 
+	.align 2
 DirectSoundWaveData_bicycle_bell::
 	.incbin "sound/direct_sound_samples/bicycle_bell.bin"
 
+	.align 2
 DirectSoundWaveData_wave_54::
 	.incbin "sound/direct_sound_samples/wave_54.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_pizzicato_strings::
 	.incbin "sound/direct_sound_samples/sc88_pizzicato_strings.bin"
 
+	.align 2
 DirectSoundWaveData_wave_56::
 	.incbin "sound/direct_sound_samples/wave_56.bin"
 
+	.align 2
 DirectSoundWaveData_wave_57::
 	.incbin "sound/direct_sound_samples/wave_57.bin"
 
+	.align 2
 DirectSoundWaveData_wave_58::
 	.incbin "sound/direct_sound_samples/wave_58.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_wind::
 	.incbin "sound/direct_sound_samples/sc88_wind.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_bubbles::
 	.incbin "sound/direct_sound_samples/sc88_bubbles.bin"
 
+	.align 2
 DirectSoundWaveData_wave_61::
 	.incbin "sound/direct_sound_samples/wave_61.bin"
 
+	.align 2
 DirectSoundWaveData_wave_62::
 	.incbin "sound/direct_sound_samples/wave_62.bin"
 
+	.align 2
 DirectSoundWaveData_unused_acid_bass::
 	.incbin "sound/direct_sound_samples/unused_acid_bass.bin"
 
+	.align 2
 DirectSoundWaveData_wave_64::
 	.incbin "sound/direct_sound_samples/wave_64.bin"
 
+	.align 2
 DirectSoundWaveData_wave_65::
 	.incbin "sound/direct_sound_samples/wave_65.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_tubular_bell::
 	.incbin "sound/direct_sound_samples/sc88_tubular_bell.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_close_hihat::
 	.incbin "sound/direct_sound_samples/unknown_close_hihat.bin"
 
+	.align 2
 DirectSoundWaveData_wave_68::
 	.incbin "sound/direct_sound_samples/wave_68.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_polysynth::
 	.incbin "sound/direct_sound_samples/unknown_polysynth.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_harp::
 	.incbin "sound/direct_sound_samples/sc88_harp.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_xylophone::
 	.incbin "sound/direct_sound_samples/sc88_xylophone.bin"
 
+	.align 2
 DirectSoundWaveData_wave_72::
 	.incbin "sound/direct_sound_samples/wave_72.bin"
 
+	.align 2
 DirectSoundWaveData_wave_73::
 	.incbin "sound/direct_sound_samples/wave_73.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_accordion::
 	.incbin "sound/direct_sound_samples/sc88_accordion.bin"
 
+	.align 2
 DirectSoundWaveData_unknown_tom::
 	.incbin "sound/direct_sound_samples/unknown_tom.bin"
 
@@ -1781,41 +1856,54 @@ Cry_Chimecho::
 
 	.align 2
 
+	.align 2
 DirectSoundWaveData_register_noise::
 	.incbin "sound/direct_sound_samples/register_noise.bin"
 
+	.align 2
 DirectSoundWaveData_wave_77::
 	.incbin "sound/direct_sound_samples/wave_77.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_nylon_str_guitar::
 	.incbin "sound/direct_sound_samples/sc88_nylon_str_guitar.bin"
 
+	.align 2
 DirectSoundWaveData_sd90_special_scream_drive::
 	.incbin "sound/direct_sound_samples/sd90_special_scream_drive.bin"
 
+	.align 2
 DirectSoundWaveData_sc88_accordion_duplicate::
 	.incbin "sound/direct_sound_samples/sc88_accordion_duplicate.bin"
 
+	.align 2
 DirectSoundWaveData_steinway_b_piano::
 	.incbin "sound/direct_sound_samples/steinway_b_piano.bin"
 
+	.align 2
 DirectSoundWaveData_sd90_classical_overdrive_guitar::
 	.incbin "sound/direct_sound_samples/sd90_classical_overdrive_guitar.bin"
 
+	.align 2
 DirectSoundWaveData_sd90_classical_distortion_guitar_high::
 	.incbin "sound/direct_sound_samples/sd90_classical_distortion_guitar_high.bin"
 
+	.align 2
 DirectSoundWaveData_sd90_classical_distortion_guitar_low::
 	.incbin "sound/direct_sound_samples/sd90_classical_distortion_guitar_low.bin"
 
+	.align 2
 DirectSoundWaveData_sd90_classical_whistle::
 	.incbin "sound/direct_sound_samples/sd90_classical_whistle.bin"
 
+	.align 2
 DirectSoundWaveData_sd90_classical_detuned_ep1_low::
 	.incbin "sound/direct_sound_samples/sd90_classical_detuned_ep1_low.bin"
 
+	.align 2
 DirectSoundWaveData_sd90_classical_detuned_ep1_high::
 	.incbin "sound/direct_sound_samples/sd90_classical_detuned_ep1_high.bin"
 
+	.align 2
 DirectSoundWaveData_sd90_enhanced_delay_shaku::
 	.incbin "sound/direct_sound_samples/sd90_enhanced_delay_shaku.bin"


### PR DESCRIPTION
The vanilla samples seem to be aligned naturally, but using any other samples causes them to break alignment, making the audio completely garbled.