### PR TITLE
Split connection field from graphics id in object events

### DIFF
--- a/asm/macros/map.inc
+++ b/asm/macros/map.inc
@@ -14,9 +14,10 @@
 	.4byte \address
 	.endm
 
-	.macro object_event index:req, gfx:req, x:req, y:req, elevation:req, movement_type:req, x_radius:req, y_radius:req, trainer_type:req, sight_radius_tree_etc:req, script:req, event_flag:req
+	.macro object_event index:req, gfx:req, in_connection:req x:req, y:req, elevation:req, movement_type:req, x_radius:req, y_radius:req, trainer_type:req, sight_radius_tree_etc:req, script:req, event_flag:req
 	.byte \index
-	.2byte \gfx
+	.byte \gfx
+	.byte \in_connection
 	.byte 0
 	.2byte \x, \y
 	.byte \elevation, \movement_type, ((\y_radius << 4) | \x_radius), 0

--- a/data/maps/CeladonCity/map.json
+++ b/data/maps/CeladonCity/map.json
@@ -183,8 +183,9 @@
       "flag": "0"
     },
     {
-      "graphics_id": "65375",
-      "x": 65529,
+      "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
+      "in_connection": 255,
+      "x": -7,
       "y": 21,
       "elevation": 7,
       "movement_type": "MOVEMENT_TYPE_NONE",

--- a/data/maps/CeladonCity/map.json
+++ b/data/maps/CeladonCity/map.json
@@ -184,7 +184,7 @@
     },
     {
       "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
-      "in_connection": 255,
+      "in_connection": true,
       "x": -7,
       "y": 21,
       "elevation": 7,

--- a/data/maps/CeruleanCity/map.json
+++ b/data/maps/CeruleanCity/map.json
@@ -154,7 +154,8 @@
       "flag": "FLAG_TEMP_13"
     },
     {
-      "graphics_id": "65375",
+      "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
+      "in_connection": 255,
       "x": 50,
       "y": 18,
       "elevation": 10,

--- a/data/maps/CeruleanCity/map.json
+++ b/data/maps/CeruleanCity/map.json
@@ -155,7 +155,7 @@
     },
     {
       "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
-      "in_connection": 255,
+      "in_connection": true,
       "x": 50,
       "y": 18,
       "elevation": 10,

--- a/data/maps/FiveIsland/map.json
+++ b/data/maps/FiveIsland/map.json
@@ -53,7 +53,8 @@
       "flag": "0"
     },
     {
-      "graphics_id": "65375",
+      "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
+      "in_connection": 255,
       "x": 32,
       "y": 9,
       "elevation": 4,

--- a/data/maps/FiveIsland/map.json
+++ b/data/maps/FiveIsland/map.json
@@ -54,7 +54,7 @@
     },
     {
       "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
-      "in_connection": 255,
+      "in_connection": true,
       "x": 32,
       "y": 9,
       "elevation": 4,

--- a/data/maps/Route15/map.json
+++ b/data/maps/Route15/map.json
@@ -197,7 +197,7 @@
     },
     {
       "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
-      "in_connection": 255,
+      "in_connection": true,
       "x": 73,
       "y": 7,
       "elevation": 13,

--- a/data/maps/Route15/map.json
+++ b/data/maps/Route15/map.json
@@ -196,7 +196,8 @@
       "flag": "0"
     },
     {
-      "graphics_id": "65375",
+      "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
+      "in_connection": 255,
       "x": 73,
       "y": 7,
       "elevation": 13,

--- a/data/maps/Route2/map.json
+++ b/data/maps/Route2/map.json
@@ -105,7 +105,8 @@
       "flag": "FLAG_HIDE_ROUTE2_PARALYZE_HEAL"
     },
     {
-      "graphics_id": "65375",
+      "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
+      "in_connection": 255,
       "x": 6,
       "y": 85,
       "elevation": 8,

--- a/data/maps/Route2/map.json
+++ b/data/maps/Route2/map.json
@@ -106,7 +106,7 @@
     },
     {
       "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
-      "in_connection": 255,
+      "in_connection": true,
       "x": 6,
       "y": 85,
       "elevation": 8,

--- a/data/maps/Route21_North/map.json
+++ b/data/maps/Route21_North/map.json
@@ -93,7 +93,7 @@
     },
     {
       "graphics_id": "OBJECT_EVENT_GFX_FAT_MAN",
-      "in_connection": 255,
+      "in_connection": true,
       "x": 13,
       "y": -3,
       "elevation": 2,

--- a/data/maps/Route21_North/map.json
+++ b/data/maps/Route21_North/map.json
@@ -92,9 +92,10 @@
       "flag": "0"
     },
     {
-      "graphics_id": "65307",
+      "graphics_id": "OBJECT_EVENT_GFX_FAT_MAN",
+      "in_connection": 255,
       "x": 13,
-      "y": 65533,
+      "y": -3,
       "elevation": 2,
       "movement_type": "MOVEMENT_TYPE_NONE",
       "movement_range_x": 0,

--- a/data/maps/Route4/map.json
+++ b/data/maps/Route4/map.json
@@ -105,7 +105,8 @@
       "flag": "0"
     },
     {
-      "graphics_id": "65321",
+      "graphics_id": "OBJECT_EVENT_GFX_COOLTRAINER_M",
+      "in_connection": 255,
       "x": 109,
       "y": 3,
       "elevation": 12,

--- a/data/maps/Route4/map.json
+++ b/data/maps/Route4/map.json
@@ -106,7 +106,7 @@
     },
     {
       "graphics_id": "OBJECT_EVENT_GFX_COOLTRAINER_M",
-      "in_connection": 255,
+      "in_connection": true,
       "x": 109,
       "y": 3,
       "elevation": 12,

--- a/data/maps/Route7/map.json
+++ b/data/maps/Route7/map.json
@@ -27,8 +27,9 @@
   ],
   "object_events": [
     {
-      "graphics_id": "65375",
-      "x": 65528,
+      "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
+      "in_connection": 255,
+      "x": -8,
       "y": 12,
       "elevation": 10,
       "movement_type": "MOVEMENT_TYPE_NONE",

--- a/data/maps/Route7/map.json
+++ b/data/maps/Route7/map.json
@@ -28,7 +28,7 @@
   "object_events": [
     {
       "graphics_id": "OBJECT_EVENT_GFX_CUT_TREE",
-      "in_connection": 255,
+      "in_connection": true,
       "x": -8,
       "y": 12,
       "elevation": 10,

--- a/data/maps/SevenIsland_SevaultCanyon_Entrance/map.json
+++ b/data/maps/SevenIsland_SevaultCanyon_Entrance/map.json
@@ -106,7 +106,7 @@
     },
     {
       "graphics_id": "OBJECT_EVENT_GFX_COOLTRAINER_M",
-      "in_connection": 255,
+      "in_connection": true,
       "x": 7,
       "y": -2,
       "elevation": 1,

--- a/data/maps/SevenIsland_SevaultCanyon_Entrance/map.json
+++ b/data/maps/SevenIsland_SevaultCanyon_Entrance/map.json
@@ -105,9 +105,10 @@
       "flag": "0"
     },
     {
-      "graphics_id": "65321",
+      "graphics_id": "OBJECT_EVENT_GFX_COOLTRAINER_M",
+      "in_connection": 255,
       "x": 7,
-      "y": 65534,
+      "y": -2,
       "elevation": 1,
       "movement_type": "MOVEMENT_TYPE_NONE",
       "movement_range_x": 0,

--- a/tools/mapjson/mapjson.cpp
+++ b/tools/mapjson/mapjson.cpp
@@ -274,6 +274,7 @@ string generate_firered_map_events_text(Json map_data) {
             auto obj_event = map_data["object_events"].array_items()[i];
             text << "\tobject_event " << i + 1 << ", "
                  << obj_event["graphics_id"].string_value() << ", "
+                 << obj_event["in_connection"].int_value() << ", "
                  << obj_event["x"].int_value() << ", "
                  << obj_event["y"].int_value() << ", "
                  << obj_event["elevation"].int_value() << ", "

--- a/tools/mapjson/mapjson.cpp
+++ b/tools/mapjson/mapjson.cpp
@@ -274,7 +274,7 @@ string generate_firered_map_events_text(Json map_data) {
             auto obj_event = map_data["object_events"].array_items()[i];
             text << "\tobject_event " << i + 1 << ", "
                  << obj_event["graphics_id"].string_value() << ", "
-                 << obj_event["in_connection"].int_value() << ", "
+                 << (obj_event["in_connection"].bool_value() ? 255 : 0) << ", "
                  << obj_event["x"].int_value() << ", "
                  << obj_event["y"].int_value() << ", "
                  << obj_event["elevation"].int_value() << ", "


### PR DESCRIPTION
These are the objects which are positioned in the connection to a different map, indicated by having the field after graphics id set to 0xFF rather than 0. With a few exceptions (the Fat Man in Pallet Town coming from 21, the NPC guarding Cerulean Cave coming from Route 4, and a trainer on the bridge in Sevault Canyon Entrance) all of them are Cut Trees. By definition their coordinates are outside the bounds of the map, and can be negative.

~~This is sort of an interim solution, it might be preferable if the field was a bool. Alternatively the field could be renamed, listed for all object events, and have two constants like `OBJ_IN_CONNECTION` for 255 and `OBJ_IN_MAP` for 0~~
updated to bool