### PR TITLE
Removed unused defines in include/battle_script_commands.h

### DIFF
--- a/include/battle_script_commands.h
+++ b/include/battle_script_commands.h
@@ -3,24 +3,6 @@
 
 #include "global.h"
 
-#define NO_ACC_CALC 0xFFFE
-#define NO_ACC_CALC_CHECK_LOCK_ON 0xFFFF
-#define ACC_CURR_MOVE 0
-
-#define ATK48_STAT_NEGATIVE         0x1
-#define ATK48_STAT_BY_TWO           0x2
-#define ATK48_BIT_x4                0x4
-#define ATK48_LOWER_FAIL_CHECK      0x8
-
-#define ATK4F_DONT_CHECK_STATUSES   0x80
-
-#define ATK80_DMG_CHANGE_SIGN                               0
-#define ATK80_DMG_HALF_BY_TWO_NOT_MORE_THAN_HALF_MAX_HP     1
-#define ATK80_DMG_DOUBLED                                   2
-
-#define STAT_CHANGE_BS_PTR                  0x1
-#define STAT_CHANGE_NOT_PROTECT_AFFECTED    0x20
-
 #define STAT_CHANGE_WORKED      0
 #define STAT_CHANGE_DIDNT_WORK  1
 


### PR DESCRIPTION
These are already present in include/constants/battle_script_commands.h

I tend to screw things up a lot, so if anyone sees anything wrong here please let me know.