### PR TITLE
Bump devkitARM to r52

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ install:
   - pushd $HOME
   - travis_retry wget https://github.com/devkitPro/buildscripts/releases/download/devkitARM_r52/devkitARM_r52-linux.tar.xz
   - tar xJf devkitARM*.tar.xz
+  - travis_retry wget https://github.com/devkitPro/devkitarm-rules/releases/download/v1.0.0/devkitarm-rules-1.0.0.tar.xz
+  - tar xJf devkitarm-rules-*.tar.xz -C $DEVKITARM
   - travis_retry git clone https://github.com/pret/agbcc.git
   - cd agbcc && sh build.sh && sh install.sh $TRAVIS_BUILD_DIR
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
   apt: true
 install:
   - pushd $HOME
-  - travis_retry wget https://github.com/devkitPro/buildscripts/releases/download/devkitARM_r50/devkitARM_r50-linux.tar.xz
+  - travis_retry wget https://github.com/devkitPro/buildscripts/releases/download/devkitARM_r52/devkitARM_r52-linux.tar.xz
   - tar xJf devkitARM*.tar.xz
   - travis_retry git clone https://github.com/pret/agbcc.git
   - cd agbcc && sh build.sh && sh install.sh $TRAVIS_BUILD_DIR


### PR DESCRIPTION
Required since devkitPro decided to delete the version we were using.