### PR TITLE
fix librfu issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.gbapal
 *.hwjpnfont
 *.i
+*.idb
 *.id0
 *.id1
 *.id2

--- a/include/librfu.h
+++ b/include/librfu.h
@@ -90,13 +90,8 @@
 
 #define RFU_MBOOT_DOWNLOADER_SERIAL_NO  0x0000             // The game serial number of the multi-boot downloader (programs that boot without a Game Pak)
 
-#if LIBRFU_VERSION >= 1028
-#define RFU_API_BUFF_SIZE_RAM           0x0e8c             // Necessary size for buffer specified by rfu_initializeAPI (fast communication version that operates the library SIO interrupt routines in RAM)
-#define RFU_API_BUFF_SIZE_ROM           0x052c             // Necessary size for buffer specified by rfu_initializeAPI (fast communication version that operates the library SIO interrupt routines in ROM)
-#else
 #define RFU_API_BUFF_SIZE_RAM           0x0e64             // Necessary size for buffer specified by rfu_initializeAPI (fast communication version that operates the library SIO interrupt routines in RAM)
 #define RFU_API_BUFF_SIZE_ROM           0x0504             // Necessary size for buffer specified by rfu_initializeAPI (fast communication version that operates the library SIO interrupt routines in ROM)
-#endif
 
 #define RFU_CHILD_MAX                   4                  // Maximum number of slaves that can be connected to one parent device
 

--- a/src/librfu_rfu.c
+++ b/src/librfu_rfu.c
@@ -110,7 +110,7 @@ static const struct LLSFStruct llsf_struct[2] = {
 
 #define xstr(s) str(s)
 #define str(s) #s
-const char version_string[] = "RFU_V" xstr(LIBRFU_VERSION);
+static const char version_string[] = "RFU_V" xstr(LIBRFU_VERSION);
 
 static const char str_checkMbootLL[] = "RFU-MBOOT";
 
@@ -154,16 +154,13 @@ u16 rfu_initializeAPI(u32 *APIBuffer, u16 buffByteSize, IntrFunc *sioIntrTable_p
     gRfuStatic = (void *)APIBuffer + 0xb4; // + sizeof(*gRfuLinkStatus)
     gRfuFixed = (void *)APIBuffer + 0xdc; // + sizeof(*gRfuStatic)
     gRfuSlotStatusNI[0] = (void *)APIBuffer + 0x1bc; // + sizeof(*gRfuFixed)
-    gRfuSlotStatusUNI[0] = (void *)APIBuffer + 0x37c; // + sizeof(*gRfuSlotStatusNI[0])
+    gRfuSlotStatusUNI[0] = (void *)APIBuffer + 0x37c; // + sizeof(*gRfuSlotStatusNI[0]) * RFU_CHILD_MAX
     for (i = 1; i < RFU_CHILD_MAX; ++i)
     {
         gRfuSlotStatusNI[i] = &gRfuSlotStatusNI[i - 1][1];
         gRfuSlotStatusUNI[i] = &gRfuSlotStatusUNI[i - 1][1];
     }
-    // TODO: Is it possible to fix the following 2 statements?
-    // It's equivalent to:
-    // gRfuFixed->STWIBuffer = &APIBuffer->intr;
-    // STWI_init_all(&APIBuffer->intr, sioIntrTable_p, copyInterruptToRam);
+    // remaining space in API buffer is used for `struct RfuIntrStruct`. 
     gRfuFixed->STWIBuffer = (struct RfuIntrStruct *)&gRfuSlotStatusUNI[3][1];
     STWI_init_all((struct RfuIntrStruct *)&gRfuSlotStatusUNI[3][1], sioIntrTable_p, copyInterruptToRam);
     rfu_STC_clearAPIVariables();


### PR DESCRIPTION
After decompiling librfu v1.0.21, I confirmed the difference of API buffer size between SDK manual and header is very likely caused by carelessness. In v1.0.21, it's really using the constants in header which is 0x28 bytes larger than that in the manual. 

This is because, in v1.0.21, some fields in latest `struct RfuStatic` were placed in `.bss` as separate variables, so `struct RfuStatic` is 0x10 bytes smaller there. and for some unknown reason, the API buffer was designed to hold 2 more `struct RfuSlotStatusUNI` (both unused I believe, maybe this is the change indicated by `* Removed all of the RFU library variables related to key sharing.`)

so the difference can be computed as: -2 * (sizeof(struct RfuSlotStatusUNI)) + 0x10 = -0x28. 