### PR TITLE
Add MAX_MAP_DATA_SIZE alias

### DIFF
--- a/include/fieldmap.h
+++ b/include/fieldmap.h
@@ -9,7 +9,8 @@
 #define NUM_METATILES_TOTAL 1024
 #define NUM_PALS_IN_PRIMARY 7
 #define NUM_PALS_TOTAL 13
-#define VIRTUAL_MAP_SIZE 0x2800
+#define MAX_MAP_DATA_SIZE 0x2800
+#define VIRTUAL_MAP_SIZE (MAX_MAP_DATA_SIZE)
 
 extern struct BackupMapLayout VMap;
 extern const struct MapLayout Route1_Layout;


### PR DESCRIPTION
`VIRTUAL_MAP_SIZE` is an assert name, `MAX_MAP_DATA_SIZE` is clearer and used by pokeemerald/porymap