### PR TITLE
Update Audio Macros

### DIFF
--- a/asm/macros/music_voice.inc
+++ b/asm/macros/music_voice.inc
@@ -1,19 +1,19 @@
-	.macro voice_directsound base_midi_key, pan, sample_data_pointer, attack, decay, sustain, release
+	.macro voice_directsound base_midi_key:req, pan:req, sample_data_pointer:req, attack:req, decay:req, sustain:req, release:req
 	.byte 0
 	_voice_directsound \base_midi_key, \pan, \sample_data_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_directsound_no_resample base_midi_key, pan, sample_data_pointer, attack, decay, sustain, release
+	.macro voice_directsound_no_resample base_midi_key:req, pan:req, sample_data_pointer:req, attack:req, decay:req, sustain:req, release:req
 	.byte 8
 	_voice_directsound \base_midi_key, \pan, \sample_data_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_directsound_alt base_midi_key, pan, sample_data_pointer, attack, decay, sustain, release
+	.macro voice_directsound_alt base_midi_key:req, pan:req, sample_data_pointer:req, attack:req, decay:req, sustain:req, release:req
 	.byte 16
 	_voice_directsound \base_midi_key, \pan, \sample_data_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_directsound base_midi_key, pan, sample_data_pointer, attack, decay, sustain, release
+	.macro _voice_directsound base_midi_key:req, pan:req, sample_data_pointer:req, attack:req, decay:req, sustain:req, release:req
 	.byte \base_midi_key
 	.byte 0
 	.if \pan != 0
@@ -28,16 +28,22 @@
 	.byte \release
 	.endm
 
-	.macro voice_square_1 sweep, duty_cycle, attack, decay, sustain, release
-	_voice_square_1 1, \sweep, \duty_cycle, \attack, \decay, \sustain, \release
+	.macro voice_square_1 base_midi_key:req, pan:req, sweep:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
+	_voice_square_1 1, \base_midi_key, \pan, \sweep, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_square_1_alt sweep, duty_cycle, attack, decay, sustain, release
-	_voice_square_1 9, \sweep, \duty_cycle, \attack, \decay, \sustain, \release
+	.macro voice_square_1_alt base_midi_key:req, pan:req, sweep:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
+	_voice_square_1 9, \base_midi_key, \pan, \sweep, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_square_1 type, sweep, duty_cycle, attack, decay, sustain, release
-	.byte \type, 60, 0
+	.macro _voice_square_1 type:req, base_midi_key:req, pan:req, sweep:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
+	.byte \type
+	.byte \base_midi_key
+	.if \pan != 0
+	.byte (0x80 | \pan)
+	.else
+	.byte 0
+	.endif
 	.byte \sweep
 	.byte (\duty_cycle & 0x3)
 	.byte 0, 0, 0
@@ -47,16 +53,23 @@
 	.byte (\release & 0x7)
 	.endm
 
-	.macro voice_square_2 duty_cycle, attack, decay, sustain, release
-	_voice_square_2 2, \duty_cycle, \attack, \decay, \sustain, \release
+	.macro voice_square_2 base_midi_key:req, pan:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
+	_voice_square_2 2, \base_midi_key, \pan, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_square_2_alt duty_cycle, attack, decay, sustain, release
-	_voice_square_2 10, \duty_cycle, \attack, \decay, \sustain, \release
+	.macro voice_square_2_alt base_midi_key:req, pan:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
+	_voice_square_2 10, \base_midi_key, \pan, \duty_cycle, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_square_2 type, duty_cycle, attack, decay, sustain, release
-	.byte \type, 60, 0, 0
+	.macro _voice_square_2 type:req, base_midi_key:req, pan:req, duty_cycle:req, attack:req, decay:req, sustain:req, release:req
+	.byte \type
+	.byte \base_midi_key
+	.if \pan != 0
+	.byte (0x80 | \pan)
+	.else
+	.byte 0
+	.endif
+	.byte 0
 	.byte (\duty_cycle & 0x3)
 	.byte 0, 0, 0
 	.byte (\attack  & 0x7)
@@ -65,16 +78,23 @@
 	.byte (\release & 0x7)
 	.endm
 
-	.macro voice_programmable_wave wave_samples_pointer, attack, decay, sustain, release
-	_voice_programmable_wave 3, \wave_samples_pointer, \attack, \decay, \sustain, \release
+	.macro voice_programmable_wave base_midi_key:req, pan:req, wave_samples_pointer:req, attack:req, decay:req, sustain:req, release:req
+	_voice_programmable_wave 3, \base_midi_key, \pan, \wave_samples_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_programmable_wave_alt wave_samples_pointer, attack, decay, sustain, release
-	_voice_programmable_wave 11, \wave_samples_pointer, \attack, \decay, \sustain, \release
+	.macro voice_programmable_wave_alt base_midi_key:req, pan:req, wave_samples_pointer:req, attack:req, decay:req, sustain:req, release:req
+	_voice_programmable_wave 11, \base_midi_key, \pan, \wave_samples_pointer, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_programmable_wave type, wave_samples_pointer, attack, decay, sustain, release
-	.byte \type, 60, 0, 0
+	.macro _voice_programmable_wave type:req, base_midi_key:req, pan:req, wave_samples_pointer:req, attack:req, decay:req, sustain:req, release:req
+	.byte \type
+	.byte \base_midi_key
+	.if \pan != 0
+	.byte (0x80 | \pan)
+	.else
+	.byte 0
+	.endif
+	.byte 0
 	.4byte \wave_samples_pointer
 	.byte (\attack  & 0x7)
 	.byte (\decay   & 0x7)
@@ -82,16 +102,23 @@
 	.byte (\release & 0x7)
 	.endm
 
-	.macro voice_noise period, attack, decay, sustain, release
-	_voice_noise 4, \period, \attack, \decay, \sustain, \release
+	.macro voice_noise base_midi_key:req, pan:req, period:req, attack:req, decay:req, sustain:req, release:req
+	_voice_noise 4, \base_midi_key, \pan, \period, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro voice_noise_alt period, attack, decay, sustain, release
-	_voice_noise 12, \period, \attack, \decay, \sustain, \release
+	.macro voice_noise_alt base_midi_key:req, pan:req, period:req, attack:req, decay:req, sustain:req, release:req
+	_voice_noise 12, \base_midi_key, \pan, \period, \attack, \decay, \sustain, \release
 	.endm
 
-	.macro _voice_noise type, period, attack, decay, sustain, release
-	.byte \type, 60, 0, 0
+	.macro _voice_noise type:req, base_midi_key:req, pan:req, period:req, attack:req, decay:req, sustain:req, release:req
+	.byte \type
+	.byte \base_midi_key
+	.if \pan != 0
+	.byte (0x80 | \pan)
+	.else
+	.byte 0
+	.endif
+	.byte 0
 	.byte (\period & 0x1)
 	.byte 0, 0, 0
 	.byte (\attack  & 0x7)
@@ -100,25 +127,25 @@
 	.byte (\release & 0x7)
 	.endm
 
-	.macro voice_keysplit voice_group_pointer, keysplit_table_pointer
+	.macro voice_keysplit voice_group_pointer:req, keysplit_table_pointer:req
 	.byte 0x40, 0, 0, 0
 	.4byte \voice_group_pointer
 	.4byte \keysplit_table_pointer
 	.endm
 
-	.macro voice_keysplit_all voice_group_pointer
+	.macro voice_keysplit_all voice_group_pointer:req
 	.byte 0x80, 0, 0, 0
 	.4byte \voice_group_pointer
 	.4byte 0
 	.endm
 
-	.macro cry sample
+	.macro cry sample:req
 	.byte 0x20, 60, 0, 0
 	.4byte \sample
 	.byte 0xff, 0, 0xff, 0
 	.endm
 
-	.macro cry2 sample
+	.macro cry2 sample:req
 	.byte 0x30, 60, 0, 0
 	.4byte \sample
 	.byte 0xff, 0, 0xff, 0

--- a/sound/voice_groups.inc
+++ b/sound/voice_groups.inc
@@ -1,99 +1,101 @@
-
+	.align 2
 voicegroup000:: @ 8489C8C
 	voice_keysplit_all voicegroup001 @ 8489C8C
 	voice_keysplit voicegroup003, KeySplitTable1 @ 8489C98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489CA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489CB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489CBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489CC8
-	voice_square_2 2, 0, 0, 9, 2 @ 8489CD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489CE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489CC8
+	voice_square_2 60, 0, 2, 0, 0, 9, 2 @ 8489CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489CEC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_glockenspiel, 255, 165, 51, 235 @ 8489CF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D4C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 0, 255, 127 @ 8489D58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489D94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489DA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489DAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489DB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489DC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489DD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489DDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489DE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489DF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489E00
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 253, 0, 149 @ 8489E0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489E18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489E24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489E30
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_slap_bass, 255, 235, 128, 115 @ 8489E3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489E48
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 255, 252, 0, 115 @ 8489E54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489E60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489E6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489E78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489E84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489E90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489E9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489EA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489EB4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 204, 193, 239 @ 8489EC0
 	voice_keysplit voicegroup004, KeySplitTable2 @ 8489ECC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489ED8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489EE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489EF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489EFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F20
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8489F2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F68
 
+	.align 2
 voicegroup001:: @ 8489F74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489F98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489FA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489FB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489FBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489FC8
-	voice_square_1 0, 2, 0, 1, 6, 0 @ 8489FD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489FE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8489FEC
-	voice_programmable_wave gProgrammableWaveData_84A31EC, 0, 7, 15, 1 @ 8489FF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A004
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A010
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A01C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A028
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A034
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A040
-	voice_square_2 2, 0, 1, 6, 0 @ 848A04C
-	voice_programmable_wave gProgrammableWaveData_84A320C, 0, 7, 15, 1 @ 848A058
-	voice_square_1 0, 2, 0, 1, 6, 0 @ 848A064
-	voice_square_2 3, 0, 1, 6, 0 @ 848A070
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A07C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A088
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A094
-	voice_square_1 0, 0, 0, 1, 6, 0 @ 848A0A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A0AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A0B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489FC8
+	voice_square_1 60, 0, 0, 2, 0, 1, 6, 0 @ 8489FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8489FEC
+	voice_programmable_wave 60, 0, gProgrammableWaveData_84A31EC, 0, 7, 15, 1 @ 8489FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A01C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A040
+	voice_square_2 60, 0, 2, 0, 1, 6, 0 @ 848A04C
+	voice_programmable_wave 60, 0, gProgrammableWaveData_84A320C, 0, 7, 15, 1 @ 848A058
+	voice_square_1 60, 0, 0, 2, 0, 1, 6, 0 @ 848A064
+	voice_square_2 60, 0, 3, 0, 1, 6, 0 @ 848A070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A07C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A094
+	voice_square_1 60, 0, 0, 0, 0, 1, 6, 0 @ 848A0A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A0AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A0B8
 	voice_directsound 60, 0, DirectSoundWaveData_classical_choir_voice_ahhs, 255, 0, 255, 0 @ 848A0C4
 
+	.align 2
 voicegroup002:: @ 848A0D0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_oboe, 255, 165, 154, 127 @ 848A0D0
 	voice_directsound 60, 0, DirectSoundWaveData_unused_sd90_oboe, 255, 165, 154, 127 @ 848A0DC
@@ -103,33 +105,33 @@ voicegroup002:: @ 848A0D0
 	voice_directsound 60, 0, DirectSoundWaveData_ethnic_flavours_ohtsuzumi, 255, 0, 255, 0 @ 848A10C
 	voice_directsound 60, 0, DirectSoundWaveData_ethnic_flavours_hyoushigi, 255, 0, 255, 0 @ 848A118
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88pro_rnd_kick, 255, 0, 255, 242 @ 848A124
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A130
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88pro_rnd_snare, 255, 0, 255, 242 @ 848A13C
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88pro_tr909_hand_clap, 255, 255, 255, 127 @ 848A148
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88pro_orchestra_snare, 255, 0, 255, 242 @ 848A154
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A160
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A16C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A178
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A184
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A190
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A19C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A1A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A1B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A1C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A1CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A1D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A1E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A1F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A16C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A19C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A1A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A1B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A1C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A1CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A1D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A1E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A1F0
 	voice_directsound_no_resample 32, 34, DirectSoundWaveData_sc88pro_tambourine, 255, 127, 77, 204 @ 848A1FC
 	voice_directsound_no_resample 60, 14, DirectSoundWaveData_trinity_cymbal_crash, 255, 235, 0, 165 @ 848A208
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A214
 	voice_directsound_no_resample 30, 54, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 246, 0, 216 @ 848A220
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A22C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A22C
 	voice_directsound_no_resample 30, 54, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 246, 0, 216 @ 848A238
 	voice_directsound_no_resample 30, 64, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 8, 0, 255, 216 @ 848A244
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A250
 	voice_directsound_no_resample 72, 104, DirectSoundWaveData_sc88pro_mute_high_conga, 255, 0, 255, 0 @ 848A25C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A268
 	voice_directsound_no_resample 72, 94, DirectSoundWaveData_sc88pro_open_low_conga, 255, 0, 255, 0 @ 848A274
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_drum_and_percussion_kick, 255, 0, 255, 0 @ 848A280
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sd90_solo_snare, 255, 180, 175, 228 @ 848A28C
@@ -141,748 +143,760 @@ voicegroup002:: @ 848A0D0
 	voice_directsound 68, 34, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226 @ 848A2D4
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88pro_rnd_snare, 255, 0, 255, 242 @ 848A2E0
 	voice_directsound 72, 44, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226 @ 848A2EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A2F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A2F8
 	voice_directsound 76, 84, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226 @ 848A304
 	voice_directsound 80, 94, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226 @ 848A310
 	voice_directsound_no_resample 33, 89, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 848A31C
 	voice_directsound 84, 104, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 235 @ 848A328
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A334
 	voice_directsound 63, 64, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 848A340
 	voice_directsound_no_resample 64, 24, DirectSoundWaveData_dance_drums_ride_bell, 255, 165, 103, 231 @ 848A34C
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88pro_tambourine, 255, 127, 77, 204 @ 848A358
 	voice_directsound_no_resample 64, 14, DirectSoundWaveData_trinity_cymbal_crash, 255, 231, 0, 188 @ 848A364
 	voice_directsound_no_resample 64, 89, DirectSoundWaveData_sd90_cowbell, 255, 0, 255, 242 @ 848A370
 	voice_directsound_no_resample 64, 29, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 848A37C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A388
 	voice_directsound_no_resample 64, 54, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 848A394
 	voice_directsound_no_resample 64, 54, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 8, 0, 255, 216 @ 848A3A0
 	voice_directsound_no_resample 64, 94, DirectSoundWaveData_unused_heart_of_asia_indian_drum, 255, 0, 255, 0 @ 848A3AC
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88pro_mute_high_conga, 255, 0, 255, 0 @ 848A3B8
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88pro_open_low_conga, 255, 0, 255, 0 @ 848A3C4
 	voice_directsound_no_resample 64, 90, DirectSoundWaveData_sc88pro_open_low_conga, 255, 0, 255, 0 @ 848A3D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A3DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A3E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A3F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A400
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A40C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A418
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A424
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A430
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A43C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A448
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A454
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A460
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A46C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A478
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A3DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A3E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A3F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A40C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A43C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A46C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A484
 	voice_directsound_no_resample 64, 39, DirectSoundWaveData_sd90_open_triangle, 255, 242, 103, 188 @ 848A490
 	voice_directsound_no_resample 64, 79, DirectSoundWaveData_sd90_open_triangle, 255, 242, 103, 188 @ 848A49C
 	voice_directsound_no_resample 64, 39, DirectSoundWaveData_sd90_open_triangle, 255, 165, 103, 188 @ 848A4A8
 	voice_directsound_no_resample 64, 24, DirectSoundWaveData_sc88pro_jingle_bell, 255, 0, 255, 0 @ 848A4B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A4C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A4CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A4C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A4CC
 	voice_directsound_no_resample 64, 104, DirectSoundWaveData_ethnic_flavours_atarigane, 255, 0, 255, 0 @ 848A4D8
 	voice_directsound 63, 64, DirectSoundWaveData_sc88pro_taiko, 255, 0, 255, 0 @ 848A4E4
 	voice_directsound 50, 84, DirectSoundWaveData_ethnic_flavours_kotsuzumi, 255, 0, 255, 0 @ 848A4F0
 	voice_directsound 64, 84, DirectSoundWaveData_ethnic_flavours_kotsuzumi, 255, 0, 255, 0 @ 848A4FC
 
+	.align 2
 voicegroup003:: @ 848A508
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_piano1_48, 255, 252, 0, 239 @ 848A508
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_piano1_60, 255, 250, 0, 221 @ 848A514
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_piano1_72, 255, 250, 0, 221 @ 848A520
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_piano1_84, 255, 247, 0, 221 @ 848A52C
 
+	.align 2
 voicegroup004:: @ 848A538
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_string_ensemble_60, 255, 0, 255, 196 @ 848A538
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_string_ensemble_72, 255, 0, 255, 196 @ 848A544
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_string_ensemble_84, 255, 0, 255, 196 @ 848A550
 
+	.align 2
 voicegroup005:: @ 848A55C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_trumpet_60, 255, 0, 193, 127 @ 848A55C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_trumpet_72, 255, 0, 193, 127 @ 848A568
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_trumpet_84, 255, 0, 193, 127 @ 848A574
-	voice_square_1_alt 38, 2, 1, 0, 0, 0 @ 848A580
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A58C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A598
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A5A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A5B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A5BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A5C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A5D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A5E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A5EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A5F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A604
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A610
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A61C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A628
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A634
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A640
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A64C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A658
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A664
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A670
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A67C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A688
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A694
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A6A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A6AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A6B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A6C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A6D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A6DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A6E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A6F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A700
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A70C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A718
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A724
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A730
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A73C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A748
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A754
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A760
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A76C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A778
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A784
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A790
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A79C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A7A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A7B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A7C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A7CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A7D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A7E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A7F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A7FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A808
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A814
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A820
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A82C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A838
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A844
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A850
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A85C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A868
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A874
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A880
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A88C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A898
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A8A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A8B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A8BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A8C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A8D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A8E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A8EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A8F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A904
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A910
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A91C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A928
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A934
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A940
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A94C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A958
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A964
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A970
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A97C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A988
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A994
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A9A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A9AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A9B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A9C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A9D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A9DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A9E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848A9F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AA9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AAA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AAB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AAC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AACC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AAD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AAE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AAF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AAFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AB08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AB14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AB20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AB2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AB38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AB44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AB50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AB5C
-	voice_square_1_alt 36, 2, 0, 1, 4, 2 @ 848AB68
-	voice_square_1_alt 21, 2, 0, 0, 15, 2 @ 848AB74
+	voice_square_1_alt 60, 0, 38, 2, 1, 0, 0, 0 @ 848A580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A58C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A5A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A5B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A5BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A5C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A5D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A5E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A5EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A5F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A61C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A64C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A67C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A6A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A6AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A6B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A6C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A6D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A6DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A6E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A6F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A70C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A73C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A76C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A79C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A7A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A7B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A7C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A7CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A7D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A7E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A7F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A7FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A82C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A85C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A88C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A8A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A8B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A8BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A8C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A8D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A8E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A8EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A8F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A91C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A94C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A97C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A9A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A9AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A9B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A9C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A9D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A9DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A9E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848A9F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AA9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AAA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AAB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AAC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AAD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AAE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AAF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AAFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AB08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AB14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AB20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AB2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AB38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AB44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AB50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AB5C
+	voice_square_1_alt 60, 0, 36, 2, 0, 1, 4, 2 @ 848AB68
+	voice_square_1_alt 60, 0, 21, 2, 0, 0, 15, 2 @ 848AB74
 
+	.align 2
 voicegroup006:: @ 848AB80
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tuba_39, 255, 0, 255, 165 @ 848AB80
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tuba_51, 255, 0, 255, 165 @ 848AB8C
 
+	.align 2
 voicegroup007:: @ 848AB98
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_french_horn_60, 255, 0, 224, 165 @ 848AB98
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_french_horn_72, 255, 0, 218, 165 @ 848ABA4
 
+	.align 2
 voicegroup008:: @ 848ABB0
 	voice_keysplit_all voicegroup001 @ 848ABB0
 	voice_keysplit voicegroup003, KeySplitTable1 @ 848ABBC
 	voice_directsound 60, 0, DirectSoundWaveData_trinity_30303_mega_bass, 255, 178, 180, 165 @ 848ABC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ABD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ABE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ABEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ABF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AC04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AC10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ABD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ABE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ABEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ABF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AC04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AC10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_glockenspiel, 255, 165, 51, 235 @ 848AC1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AC28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AC34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AC40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AC28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AC34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AC40
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_xylophone, 255, 235, 0, 204 @ 848AC4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AC58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AC64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AC70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AC7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AC88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AC94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ACA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ACAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ACB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ACC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ACD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ACDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ACE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ACF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AD9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ADA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ADB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ADC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ADCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AC58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AC64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AC70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AC7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AC88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AC94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ACA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ACAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ACB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ACC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ACD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ACDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ACE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ACF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AD9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ADA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ADB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ADC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ADCC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 242, 0, 204 @ 848ADD8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 246, 0, 226 @ 848ADE4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 848ADF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ADFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AE08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AE14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AE20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AE2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AE38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AE44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ADFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AE08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AE14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AE20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AE2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AE38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AE44
 	voice_keysplit voicegroup005, KeySplitTable3 @ 848AE50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AE5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AE5C
 	voice_keysplit voicegroup006, KeySplitTable4 @ 848AE68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AE74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AE74
 	voice_keysplit voicegroup007, KeySplitTable5 @ 848AE80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AE8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AE98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AEA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AEB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AEBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AEC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AED4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AEE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AEEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AEF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AF04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AF10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AE8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AE98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AEA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AEB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AEBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AEC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AEE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AEEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AEF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AF04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AF10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 848AF1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AF28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AF34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AF40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AF4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AF58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AF64
-	voice_square_2_alt 2, 0, 1, 7, 1 @ 848AF70
-	voice_square_1_alt 0, 2, 0, 1, 7, 1 @ 848AF7C
-	voice_square_2_alt 3, 0, 1, 7, 1 @ 848AF88
-	voice_square_1_alt 0, 3, 0, 1, 7, 1 @ 848AF94
-	voice_square_2_alt 2, 0, 1, 4, 1 @ 848AFA0
-	voice_square_1_alt 0, 2, 0, 1, 4, 1 @ 848AFAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AFB8
-	voice_programmable_wave_alt gProgrammableWaveData_84A323C, 0, 7, 15, 2 @ 848AFC4
-	voice_programmable_wave_alt gProgrammableWaveData_84A324C, 0, 7, 15, 2 @ 848AFD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848AFDC
-	voice_square_2 2, 0, 1, 4, 1 @ 848AFE8
-	voice_square_1 0, 2, 0, 1, 4, 1 @ 848AFF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B000
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B00C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B018
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B024
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B030
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B03C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B048
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B054
-	voice_square_1_alt 29, 2, 0, 2, 0, 0 @ 848B060
-	voice_square_1_alt 22, 2, 0, 2, 0, 0 @ 848B06C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AF28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AF34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AF40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AF4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AF58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AF64
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 1 @ 848AF70
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 1 @ 848AF7C
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 1 @ 848AF88
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 1 @ 848AF94
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1 @ 848AFA0
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1 @ 848AFAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AFB8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A323C, 0, 7, 15, 2 @ 848AFC4
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A324C, 0, 7, 15, 2 @ 848AFD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848AFDC
+	voice_square_2 60, 0, 2, 0, 1, 4, 1 @ 848AFE8
+	voice_square_1 60, 0, 0, 2, 0, 1, 4, 1 @ 848AFF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B00C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B03C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B054
+	voice_square_1_alt 60, 0, 29, 2, 0, 2, 0, 0 @ 848B060
+	voice_square_1_alt 60, 0, 22, 2, 0, 2, 0, 0 @ 848B06C
 
+	.align 2
 voicegroup009:: @ 848B078
 	voice_keysplit_all voicegroup001 @ 848B078
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B084
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B090
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B09C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B0A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B0B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B0C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B0CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B0D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B0E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B0F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B0FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B108
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B114
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B120
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B12C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B138
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B144
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B150
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B15C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B168
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B174
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B180
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B18C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B198
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B1A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B1B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B1BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B1C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B1D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B1E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B1EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B1F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B204
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B210
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B21C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B228
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B234
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B240
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B24C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B258
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B264
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B270
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B27C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B288
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B294
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B2A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B09C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B0A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B0B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B0C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B0CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B0D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B0E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B0F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B0FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B12C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B15C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B18C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B1A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B1B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B1BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B1C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B1D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B1E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B1EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B1F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B21C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B24C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B27C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B2A0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 246, 0, 226 @ 848B2AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B2B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B2C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B2D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B2DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B2E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B2F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B300
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B30C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B318
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B324
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B330
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B33C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B2B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B2C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B2D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B2DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B2E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B2F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B30C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B33C
 	voice_keysplit voicegroup007, KeySplitTable5 @ 848B348
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B354
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B360
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B36C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B378
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B384
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B390
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B39C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B3A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B3B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B3C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B3CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B3D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B3E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B3F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B3FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B408
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B414
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B420
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B42C
-	voice_square_2_alt 2, 0, 1, 9, 0 @ 848B438
-	voice_programmable_wave_alt gProgrammableWaveData_84A324C, 0, 7, 15, 0 @ 848B444
-	voice_square_1_alt 0, 2, 0, 1, 9, 0 @ 848B450
-	voice_square_2_alt 3, 0, 1, 7, 0 @ 848B45C
-	voice_square_1_alt 0, 3, 0, 1, 7, 0 @ 848B468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B36C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B39C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B3A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B3B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B3C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B3CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B3D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B3E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B3F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B3FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B42C
+	voice_square_2_alt 60, 0, 2, 0, 1, 9, 0 @ 848B438
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A324C, 0, 7, 15, 0 @ 848B444
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 9, 0 @ 848B450
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 0 @ 848B45C
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 0 @ 848B468
 
+	.align 2
 voicegroup010:: @ 848B474
 	voice_keysplit_all voicegroup001 @ 848B474
 	voice_keysplit voicegroup003, KeySplitTable1 @ 848B480
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B48C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B498
-	voice_square_2 2, 0, 2, 6, 1 @ 848B4A4
-	voice_square_1 0, 2, 0, 2, 6, 1 @ 848B4B0
-	voice_square_2 3, 0, 2, 4, 1 @ 848B4BC
-	voice_square_1 0, 3, 0, 2, 4, 1 @ 848B4C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B4D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B4E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B4EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B4F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B504
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B510
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B51C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B528
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B534
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B540
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B54C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B558
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B564
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B570
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B57C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B588
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B594
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B5A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B5AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B5B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B5C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B5D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B5DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B5E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B5F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B48C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B498
+	voice_square_2 60, 0, 2, 0, 2, 6, 1 @ 848B4A4
+	voice_square_1 60, 0, 0, 2, 0, 2, 6, 1 @ 848B4B0
+	voice_square_2 60, 0, 3, 0, 2, 4, 1 @ 848B4BC
+	voice_square_1 60, 0, 0, 3, 0, 2, 4, 1 @ 848B4C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B4D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B4E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B4EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B4F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B51C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B54C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B57C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B5A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B5AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B5B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B5C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B5D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B5DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B5E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B5F4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fingered_bass, 255, 253, 0, 149 @ 848B600
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B60C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B618
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B624
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B630
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B63C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B648
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B654
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B660
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B66C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B678
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B60C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B63C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B66C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B684
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_pizzicato_strings, 255, 216, 0, 165 @ 848B690
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B69C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B69C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 246, 0, 226 @ 848B6A8
 	voice_keysplit voicegroup004, KeySplitTable2 @ 848B6B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B6C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B6CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B6D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B6E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B6F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B6FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B6C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B6CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B6D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B6E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B6F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B6FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B708
 	voice_keysplit voicegroup005, KeySplitTable3 @ 848B714
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B720
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B72C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B72C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B738
 	voice_keysplit voicegroup007, KeySplitTable5 @ 848B744
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B750
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B75C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B768
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B774
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B780
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B78C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B798
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B7A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B7B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B7BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B7C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B7D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B7E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B7EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B7F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B804
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B810
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B81C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B828
-	voice_square_2 2, 0, 1, 7, 1 @ 848B834
-	voice_programmable_wave_alt gProgrammableWaveData_84A320C, 0, 7, 15, 2 @ 848B840
-	voice_square_1 0, 2, 0, 1, 7, 1 @ 848B84C
-	voice_square_1 0, 2, 0, 0, 7, 1 @ 848B858
-	voice_square_2 3, 0, 1, 7, 1 @ 848B864
-	voice_square_1 0, 3, 0, 1, 7, 1 @ 848B870
-	voice_square_1 0, 3, 0, 0, 7, 1 @ 848B87C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B888
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B894
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B8A0
-	voice_programmable_wave_alt gProgrammableWaveData_84A324C, 0, 7, 15, 2 @ 848B8AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B75C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B78C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B7A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B7B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B7BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B7C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B7D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B7E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B7EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B7F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B81C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B828
+	voice_square_2 60, 0, 2, 0, 1, 7, 1 @ 848B834
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A320C, 0, 7, 15, 2 @ 848B840
+	voice_square_1 60, 0, 0, 2, 0, 1, 7, 1 @ 848B84C
+	voice_square_1 60, 0, 0, 2, 0, 0, 7, 1 @ 848B858
+	voice_square_2 60, 0, 3, 0, 1, 7, 1 @ 848B864
+	voice_square_1 60, 0, 0, 3, 0, 1, 7, 1 @ 848B870
+	voice_square_1 60, 0, 0, 3, 0, 0, 7, 1 @ 848B87C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B8A0
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A324C, 0, 7, 15, 2 @ 848B8AC
 
+	.align 2
 voicegroup011:: @ 848B8B8
 	voice_keysplit_all voicegroup001 @ 848B8B8
 	voice_keysplit voicegroup003, KeySplitTable1 @ 848B8C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B8D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B8DC
-	voice_square_2 0, 0, 2, 4, 1 @ 848B8E8
-	voice_square_1 0, 0, 0, 2, 4, 1 @ 848B8F4
-	voice_square_2 3, 0, 1, 7, 1 @ 848B900
-	voice_square_1 0, 3, 0, 1, 7, 1 @ 848B90C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B918
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B924
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B930
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B93C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B948
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B954
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B960
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B96C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B8D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B8DC
+	voice_square_2 60, 0, 0, 0, 2, 4, 1 @ 848B8E8
+	voice_square_1 60, 0, 0, 0, 0, 2, 4, 1 @ 848B8F4
+	voice_square_2 60, 0, 3, 0, 1, 7, 1 @ 848B900
+	voice_square_1 60, 0, 0, 3, 0, 1, 7, 1 @ 848B90C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B93C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B96C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B978
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 0, 255, 127 @ 848B984
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B990
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B99C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B9A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B9B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B9C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B9CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B9D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B9E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B9F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848B9FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B99C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B9A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B9B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B9C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B9CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B9D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B9E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B9F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848B9FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA38
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fingered_bass, 255, 253, 0, 149 @ 848BA44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BA98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BAA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BAB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BABC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BAC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BAD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BA98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BAA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BAB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BAC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BAD4
 	voice_directsound_no_resample 60, 0, DirectSoundWaveData_sc88pro_timpani_with_snare, 255, 246, 0, 226 @ 848BAE0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 246, 0, 226 @ 848BAEC
 	voice_keysplit voicegroup004, KeySplitTable2 @ 848BAF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BB04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BB10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BB1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BB28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BB34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BB40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BB4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BB04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BB10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BB1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BB28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BB34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BB40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BB4C
 	voice_keysplit voicegroup005, KeySplitTable3 @ 848BB58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BB64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BB70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BB7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BB64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BB70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BB7C
 	voice_keysplit voicegroup007, KeySplitTable5 @ 848BB88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BB94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BBA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BBAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BBB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BBC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BBD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BBDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BBE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BBF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BC00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BC0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BC18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BC24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BC30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BC3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BC48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BC54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BC60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BC6C
-	voice_square_2 2, 0, 1, 7, 1 @ 848BC78
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 2 @ 848BC84
-	voice_square_1 0, 2, 0, 1, 7, 1 @ 848BC90
-	voice_square_2 1, 0, 1, 9, 1 @ 848BC9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BCA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BCB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BCC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BCCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BCD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BCE4
-	voice_programmable_wave_alt gProgrammableWaveData_84A324C, 0, 7, 15, 2 @ 848BCF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BB94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BBA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BBAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BBB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BBC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BBD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BBDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BBE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BBF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BC00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BC0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BC18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BC24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BC30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BC3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BC48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BC54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BC60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BC6C
+	voice_square_2 60, 0, 2, 0, 1, 7, 1 @ 848BC78
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 2 @ 848BC84
+	voice_square_1 60, 0, 0, 2, 0, 1, 7, 1 @ 848BC90
+	voice_square_2 60, 0, 1, 0, 1, 9, 1 @ 848BC9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BCA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BCB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BCC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BCCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BCD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BCE4
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A324C, 0, 7, 15, 2 @ 848BCF0
 
+	.align 2
 voicegroup012:: @ 848BCFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BCFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BCFC
 	voice_keysplit voicegroup003, KeySplitTable1 @ 848BD08
 
+	.align 2
 voicegroup127:: @ 848BD14
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_synth_snare, 255, 249, 103, 165 @ 848BD14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BD20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BD2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BD38
-	voice_square_1_alt 0, 2, 0, 2, 0, 0 @ 848BD44
-	voice_square_1_alt 0, 0, 0, 2, 0, 1 @ 848BD50
-	voice_square_1_alt 0, 2, 0, 4, 0, 1 @ 848BD5C
-	voice_square_1_alt 44, 2, 0, 4, 0, 0 @ 848BD68
-	voice_square_1_alt 38, 0, 0, 4, 0, 0 @ 848BD74
-	voice_square_1_alt 0, 0, 0, 7, 0, 0 @ 848BD80
-	voice_square_1_alt 0, 2, 2, 0, 15, 0 @ 848BD8C
-	voice_square_1_alt 0, 1, 2, 0, 15, 0 @ 848BD98
-	voice_square_1_alt 23, 1, 0, 1, 9, 0 @ 848BDA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BD20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BD2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BD38
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 0, 0 @ 848BD44
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 0, 1 @ 848BD50
+	voice_square_1_alt 60, 0, 0, 2, 0, 4, 0, 1 @ 848BD5C
+	voice_square_1_alt 60, 0, 44, 2, 0, 4, 0, 0 @ 848BD68
+	voice_square_1_alt 60, 0, 38, 0, 0, 4, 0, 0 @ 848BD74
+	voice_square_1_alt 60, 0, 0, 0, 0, 7, 0, 0 @ 848BD80
+	voice_square_1_alt 60, 0, 0, 2, 2, 0, 15, 0 @ 848BD8C
+	voice_square_1_alt 60, 0, 0, 1, 2, 0, 15, 0 @ 848BD98
+	voice_square_1_alt 60, 0, 23, 1, 0, 1, 9, 0 @ 848BDA4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 255, 0, 255, 165 @ 848BDB0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 255, 226, 0, 165 @ 848BDBC
-	voice_square_1_alt 0, 2, 0, 6, 0, 1 @ 848BDC8
-	voice_square_1_alt 36, 0, 0, 2, 0, 0 @ 848BDD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BDE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BDEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BDF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BE94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BEA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BEAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BEB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BEC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BED0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BEDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BEE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BEF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF3C
+	voice_square_1_alt 60, 0, 0, 2, 0, 6, 0, 1 @ 848BDC8
+	voice_square_1_alt 60, 0, 36, 0, 0, 2, 0, 0 @ 848BDD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BDE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BDEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BDF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BE94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BEA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BEAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BEB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BEC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BEDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BEE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BEF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF3C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 246, 0, 226 @ 848BF48
 	voice_keysplit voicegroup004, KeySplitTable2 @ 848BF54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BF9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BFA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BFB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BFC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BFCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BFD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BFE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BFF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848BFFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C008
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C014
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C020
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C02C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C038
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C044
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C050
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C05C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C068
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C074
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C080
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C08C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C098
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C0A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C0B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C0BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C0C8
-	voice_square_2_alt 3, 0, 1, 0, 1 @ 848C0D4
-	voice_square_1_alt 0, 3, 0, 1, 0, 1 @ 848C0E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C0EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C0F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C104
-	voice_square_1_alt 46, 2, 0, 4, 0, 0 @ 848C110
-	voice_square_1_alt 38, 2, 0, 4, 0, 0 @ 848C11C
-	voice_square_1_alt 119, 2, 0, 0, 15, 1 @ 848C128
-	voice_square_1_alt 0, 2, 0, 0, 15, 1 @ 848C134
-	voice_square_1_alt 106, 2, 0, 2, 0, 0 @ 848C140
-	voice_square_1_alt 23, 2, 0, 1, 9, 0 @ 848C14C
-	voice_square_1_alt 21, 2, 0, 1, 9, 0 @ 848C158
-	voice_square_1_alt 0, 0, 0, 0, 15, 1 @ 848C164
-	voice_square_1_alt 47, 2, 0, 2, 6, 0 @ 848C170
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C17C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C188
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C194
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C1A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C1AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C1B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C1C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C1D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C1DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C1E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C1F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C200
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C20C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C218
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C224
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C230
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C23C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C248
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C254
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C260
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C26C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C278
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C284
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C290
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C29C
-	voice_noise 0, 0, 7, 15, 0 @ 848C2A8
-	voice_noise 0, 2, 7, 15, 0 @ 848C2B4
-	voice_noise_alt 0, 2, 0, 15, 0 @ 848C2C0
-	voice_noise_alt 1, 0, 0, 15, 0 @ 848C2CC
-	voice_noise_alt 0, 0, 0, 15, 0 @ 848C2D8
-	voice_noise_alt 0, 0, 3, 0, 0 @ 848C2E4
-	voice_noise_alt 0, 0, 2, 0, 0 @ 848C2F0
-	voice_noise_alt 0, 0, 1, 0, 0 @ 848C2FC
-	voice_noise_alt 0, 0, 1, 0, 1 @ 848C308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BF9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BFA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BFB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BFC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BFCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BFD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BFE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BFF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848BFFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C02C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C05C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C08C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C0A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C0B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C0BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C0C8
+	voice_square_2_alt 60, 0, 3, 0, 1, 0, 1 @ 848C0D4
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 0, 1 @ 848C0E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C0EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C0F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C104
+	voice_square_1_alt 60, 0, 46, 2, 0, 4, 0, 0 @ 848C110
+	voice_square_1_alt 60, 0, 38, 2, 0, 4, 0, 0 @ 848C11C
+	voice_square_1_alt 60, 0, 119, 2, 0, 0, 15, 1 @ 848C128
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 15, 1 @ 848C134
+	voice_square_1_alt 60, 0, 106, 2, 0, 2, 0, 0 @ 848C140
+	voice_square_1_alt 60, 0, 23, 2, 0, 1, 9, 0 @ 848C14C
+	voice_square_1_alt 60, 0, 21, 2, 0, 1, 9, 0 @ 848C158
+	voice_square_1_alt 60, 0, 0, 0, 0, 0, 15, 1 @ 848C164
+	voice_square_1_alt 60, 0, 47, 2, 0, 2, 6, 0 @ 848C170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C17C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C1A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C1AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C1B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C1C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C1D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C1DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C1E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C1F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C20C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C23C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C26C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C29C
+	voice_noise 60, 0, 0, 0, 7, 15, 0 @ 848C2A8
+	voice_noise 60, 0, 0, 2, 7, 15, 0 @ 848C2B4
+	voice_noise_alt 60, 0, 0, 2, 0, 15, 0 @ 848C2C0
+	voice_noise_alt 60, 0, 1, 0, 0, 15, 0 @ 848C2CC
+	voice_noise_alt 60, 0, 0, 0, 0, 15, 0 @ 848C2D8
+	voice_noise_alt 60, 0, 0, 0, 3, 0, 0 @ 848C2E4
+	voice_noise_alt 60, 0, 0, 0, 2, 0, 0 @ 848C2F0
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0 @ 848C2FC
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 1 @ 848C308
 
+	.align 2
 voicegroup128:: @ 848C314
 	voice_directsound_no_resample 60, 0, DirectSoundWaveData_bicycle_bell, 255, 249, 0, 165 @ 848C314
 	voice_directsound_alt 60, 0, DirectSoundWaveData_bicycle_bell, 255, 0, 255, 165 @ 848C320
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_synth_snare, 255, 0, 255, 165 @ 848C32C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_glockenspiel, 255, 242, 0, 127 @ 848C338
-	voice_noise_alt 0, 0, 1, 0, 1 @ 848C344
-	voice_noise_alt 1, 0, 1, 0, 1 @ 848C350
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 1 @ 848C344
+	voice_noise_alt 60, 0, 1, 0, 1, 0, 1 @ 848C350
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 0, 255, 165 @ 848C35C
-	voice_square_1_alt 0, 2, 0, 2, 0, 1 @ 848C368
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 0, 1 @ 848C368
 	voice_directsound 60, 0, DirectSoundWaveData_wave_54, 255, 0, 255, 165 @ 848C374
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_pizzicato_strings, 255, 0, 255, 127 @ 848C380
 	voice_directsound 60, 0, DirectSoundWaveData_wave_56, 255, 0, 255, 127 @ 848C38C
-	voice_noise_alt 1, 0, 2, 0, 0 @ 848C398
-	voice_square_1 103, 3, 2, 7, 0, 0 @ 848C3A4
-	voice_square_2 3, 2, 7, 0, 0 @ 848C3B0
+	voice_noise_alt 60, 0, 1, 0, 2, 0, 0 @ 848C398
+	voice_square_1 60, 0, 103, 3, 2, 7, 0, 0 @ 848C3A4
+	voice_square_2 60, 0, 3, 2, 7, 0, 0 @ 848C3B0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 255, 226, 0, 127 @ 848C3BC
 	voice_directsound 60, 0, DirectSoundWaveData_wave_57, 255, 0, 255, 0 @ 848C3C8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 255, 204, 0, 127 @ 848C3D4
-	voice_square_1_alt 0, 2, 0, 2, 0, 1 @ 848C3E0
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 0, 1 @ 848C3E0
 	voice_directsound 60, 0, DirectSoundWaveData_wave_58, 255, 0, 255, 127 @ 848C3EC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 255, 0, 255, 127 @ 848C3F8
-	voice_square_1 103, 0, 0, 7, 0, 0 @ 848C404
+	voice_square_1 60, 0, 103, 0, 0, 7, 0, 0 @ 848C404
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_orchestra_snare, 255, 0, 255, 127 @ 848C410
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_wind, 255, 0, 255, 127 @ 848C41C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_bubbles, 255, 0, 255, 127 @ 848C428
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_rnd_snare, 255, 0, 255, 127 @ 848C434
-	voice_noise_alt 0, 0, 7, 15, 1 @ 848C440
+	voice_noise_alt 60, 0, 0, 0, 7, 15, 1 @ 848C440
 	voice_directsound 60, 0, DirectSoundWaveData_wave_61, 255, 0, 255, 127 @ 848C44C
-	voice_noise_alt 1, 0, 7, 15, 1 @ 848C458
+	voice_noise_alt 60, 0, 1, 0, 7, 15, 1 @ 848C458
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_glockenspiel, 255, 246, 0, 127 @ 848C464
 	voice_directsound 60, 0, DirectSoundWaveData_wave_62, 255, 0, 255, 127 @ 848C470
-	voice_square_1_alt 19, 2, 0, 2, 0, 0 @ 848C47C
+	voice_square_1_alt 60, 0, 19, 2, 0, 2, 0, 0 @ 848C47C
 	voice_directsound 60, 0, DirectSoundWaveData_trinity_30303_mega_bass, 255, 0, 255, 127 @ 848C488
-	voice_square_1 103, 0, 0, 0, 15, 0 @ 848C494
+	voice_square_1 60, 0, 103, 0, 0, 0, 15, 0 @ 848C494
 	voice_directsound_alt 60, 0, DirectSoundWaveData_wave_62, 255, 0, 255, 127 @ 848C4A0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 255, 255, 127 @ 848C4AC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 255, 0, 255, 127 @ 848C4B8
@@ -892,92 +906,92 @@ voicegroup128:: @ 848C314
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 848C4E8
 	voice_directsound 60, 0, DirectSoundWaveData_unknown_close_hihat, 255, 127, 0, 188 @ 848C4F4
 	voice_directsound 60, 0, DirectSoundWaveData_wave_68, 255, 249, 0, 165 @ 848C500
-	voice_square_1 0, 0, 4, 6, 0, 0 @ 848C50C
+	voice_square_1 60, 0, 0, 0, 4, 6, 0, 0 @ 848C50C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_glockenspiel, 13, 0, 255, 127 @ 848C518
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 13, 0, 255, 127 @ 848C524
 	voice_directsound 60, 0, DirectSoundWaveData_trinity_big_boned, 255, 0, 255, 127 @ 848C530
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 252, 0, 204 @ 848C53C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C548
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_xylophone, 255, 235, 0, 204 @ 848C554
-	voice_square_1 0, 0, 4, 0, 15, 0 @ 848C560
+	voice_square_1 60, 0, 0, 0, 4, 0, 15, 0 @ 848C560
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_xylophone, 255, 188, 0, 0 @ 848C56C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 226, 0, 127 @ 848C578
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 26, 0, 255, 127 @ 848C584
-	voice_square_1_alt 0, 2, 0, 1, 0, 0 @ 848C590
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 0, 0 @ 848C590
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_glockenspiel, 255, 252, 0, 127 @ 848C59C
-	voice_square_1_alt 0, 1, 0, 2, 0, 0 @ 848C5A8
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 0, 0 @ 848C5A8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_pizzicato_strings, 255, 127, 0, 127 @ 848C5B4
-	voice_noise_alt 0, 1, 6, 0, 0 @ 848C5C0
+	voice_noise_alt 60, 0, 0, 1, 6, 0, 0 @ 848C5C0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_slap_bass, 255, 255, 255, 127 @ 848C5CC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tr909_hand_clap, 255, 255, 255, 127 @ 848C5D8
 	voice_directsound 60, 0, DirectSoundWaveData_wave_72, 255, 255, 255, 127 @ 848C5E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_french_horn_72, 11, 242, 0, 127 @ 848C5F0
-	voice_square_1_alt 0, 2, 4, 6, 0, 0 @ 848C5FC
+	voice_square_1_alt 60, 0, 0, 2, 4, 6, 0, 0 @ 848C5FC
 	voice_directsound 60, 0, DirectSoundWaveData_wave_73, 255, 255, 255, 127 @ 848C608
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 255, 0, 255, 165 @ 848C614
 	voice_directsound 60, 0, DirectSoundWaveData_unused_sc55_tom, 255, 0, 255, 165 @ 848C620
-	voice_noise_alt 0, 5, 7, 15, 1 @ 848C62C
+	voice_noise_alt 60, 0, 0, 5, 7, 15, 1 @ 848C62C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 128, 242, 0, 165 @ 848C638
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_string_ensemble_72, 255, 0, 255, 165 @ 848C644
-	voice_square_1 0, 0, 1, 5, 0, 0 @ 848C650
-	voice_noise_alt 0, 6, 6, 0, 1 @ 848C65C
-	voice_noise_alt 0, 3, 6, 0, 1 @ 848C668
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C674
+	voice_square_1 60, 0, 0, 0, 1, 5, 0, 0 @ 848C650
+	voice_noise_alt 60, 0, 0, 6, 6, 0, 1 @ 848C65C
+	voice_noise_alt 60, 0, 0, 3, 6, 0, 1 @ 848C668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C674
 	voice_directsound 60, 0, DirectSoundWaveData_trinity_30303_mega_bass, 15, 127, 231, 127 @ 848C680
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C68C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C698
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C6A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C6B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C6BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C6C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C6D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C6E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C6EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C6F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C704
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C710
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C71C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C728
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C734
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C740
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C74C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C758
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C764
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C770
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C77C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C788
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C794
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C7A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C7AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C7B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C7C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C7D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C7DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C7E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C7F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C800
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C80C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C818
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C824
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C830
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C83C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C848
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C854
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C860
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C86C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C878
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C884
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C890
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C89C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C8A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C8B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C8C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C8CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C8D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C8E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C8F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848C8FC
-	voice_noise_alt 0, 0, 1, 12, 0 @ 848C908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C68C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C6A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C6B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C6BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C6C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C6D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C6E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C6EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C6F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C71C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C74C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C77C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C7A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C7AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C7B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C7C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C7D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C7DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C7E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C7F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C80C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C83C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C86C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C89C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C8A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C8B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C8C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C8CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C8D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C8E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C8F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848C8FC
+	voice_noise_alt 60, 0, 0, 0, 1, 12, 0 @ 848C908
 
 gCryTable:: @ 848C914
 	cry Cry_Bulbasaur @ 848C914
@@ -1759,12 +1773,13 @@ gCryTable2:: @ 848DB44
 	cry2 Cry_Deoxys @ 848ED5C
 	cry2 Cry_Chimecho @ 848ED68
 
+	.align 2
 voicegroup129:: @ 848ED74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848ED74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848ED74
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_mute_high_conga, 255, 0, 255, 0 @ 848ED80
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_open_low_conga, 255, 0, 255, 0 @ 848ED8C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tr909_hand_clap, 255, 226, 25, 0 @ 848ED98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EDA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EDA4
 	voice_directsound 60, 0, DirectSoundWaveData_wave_54, 255, 0, 255, 165 @ 848EDB0
 	voice_directsound 60, 0, DirectSoundWaveData_dance_drums_ride_bell, 255, 165, 103, 231 @ 848EDBC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_open_triangle, 255, 204, 128, 249 @ 848EDC8
@@ -1772,5581 +1787,5629 @@ voicegroup129:: @ 848ED74
 	voice_directsound 60, 0, DirectSoundWaveData_wave_77, 255, 0, 206, 204 @ 848EDE0
 	voice_directsound 60, 0, DirectSoundWaveData_ethnic_flavours_ohtsuzumi, 255, 0, 206, 38 @ 848EDEC
 	voice_directsound 60, 0, DirectSoundWaveData_ethnic_flavours_hyoushigi, 255, 0, 206, 0 @ 848EDF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EE88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EE88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 165, 128, 204 @ 848EE94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EEA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EEAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EEB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EEC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EED0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EEDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EEA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EEAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EEB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EEC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EEDC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165 @ 848EEE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EEF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EF90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EEF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EF90
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 252, 0, 204 @ 848EF9C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 255, 0, 255, 165 @ 848EFA8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 255, 204, 0, 127 @ 848EFB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EFC0
-	voice_square_1_alt 0, 2, 0, 0, 15, 0 @ 848EFCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EFD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EFE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EFF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848EFFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F008
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F014
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EFC0
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 15, 0 @ 848EFCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EFD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EFE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EFF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848EFFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F020
 	voice_keysplit voicegroup006, KeySplitTable4 @ 848F02C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F038
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F044
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F050
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F05C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F068
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F074
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F080
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F08C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F098
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F0A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F0B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F0BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F0C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F0D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F0E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F0EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F0F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F104
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F110
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F11C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F128
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F134
-	voice_square_1_alt 0, 3, 0, 0, 10, 3 @ 848F140
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F14C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F158
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F164
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F170
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F17C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F188
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F194
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F1A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F1AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F1B8
-	voice_square_1_alt 0, 0, 0, 0, 15, 1 @ 848F1C4
-	voice_square_1_alt 0, 0, 0, 2, 5, 6 @ 848F1D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F1DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F1E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F1F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F200
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F20C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F218
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F224
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F230
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F23C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F248
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F254
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F260
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F26C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F278
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F284
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F290
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F29C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F2A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F2B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F2C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F2CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F2D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F2E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F2F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F2FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F308
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F314
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F320
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F32C
-	voice_noise_alt 0, 0, 1, 9, 2 @ 848F338
-	voice_noise_alt 0, 0, 4, 3, 1 @ 848F344
-	voice_noise_alt 0, 0, 1, 12, 0 @ 848F350
-	voice_noise_alt 1, 0, 1, 9, 0 @ 848F35C
-	voice_noise_alt 0, 0, 2, 6, 0 @ 848F368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F05C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F08C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F0A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F0B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F0BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F0C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F0D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F0E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F0EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F0F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F11C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F134
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 10, 3 @ 848F140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F14C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F17C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F1A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F1AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F1B8
+	voice_square_1_alt 60, 0, 0, 0, 0, 0, 15, 1 @ 848F1C4
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 5, 6 @ 848F1D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F1DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F1E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F1F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F20C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F23C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F26C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F29C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F2A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F2B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F2C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F2CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F2D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F2E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F2F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F2FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F32C
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 2 @ 848F338
+	voice_noise_alt 60, 0, 0, 0, 4, 3, 1 @ 848F344
+	voice_noise_alt 60, 0, 0, 0, 1, 12, 0 @ 848F350
+	voice_noise_alt 60, 0, 1, 0, 1, 9, 0 @ 848F35C
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 848F368
 
+	.align 2
 voicegroup130:: @ 848F374
 	voice_keysplit_all voicegroup001 @ 848F374
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F380
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F38C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F398
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F3A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F3B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F3BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F3C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F3D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F3E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F3EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F3F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F404
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F410
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F41C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F428
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F434
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F440
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F44C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F458
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F38C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F3A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F3B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F3BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F3C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F3D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F3E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F3EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F3F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F41C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F44C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F464
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion_duplicate, 255, 249, 25, 248 @ 848F470
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F47C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F488
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F494
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F4A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F4AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F4B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F4C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F4D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F4DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F4E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F4F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F500
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F50C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F518
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F524
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F530
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F53C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F548
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F554
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F560
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F56C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F578
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F584
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F590
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F59C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F5A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F5B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F5C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F5CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F5D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F5E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F5F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F5FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F608
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F614
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F620
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F62C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F638
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F644
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F650
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F65C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F668
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F674
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F680
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F68C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F698
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F6A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F6B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F6BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F6C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F6D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F6E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F6EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F6F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F704
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F710
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F71C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F728
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F734
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F740
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F74C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F758
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F764
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F770
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F77C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F788
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F794
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F7A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F7AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F7B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F7C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F7D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F7DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F7E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F7F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F800
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F80C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F818
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F824
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F830
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F83C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F848
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F854
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F860
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F86C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F878
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F884
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F890
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F89C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F8A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F8B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F8C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F8CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F8D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F8E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F8F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F8FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F908
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F914
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F920
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F92C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F938
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F944
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F950
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F95C
-	voice_noise_alt 0, 0, 1, 7, 1 @ 848F968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F47C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F4A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F4AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F4B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F4C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F4D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F4DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F4E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F4F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F50C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F53C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F56C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F59C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F5A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F5B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F5C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F5CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F5D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F5E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F5F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F5FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F62C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F65C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F68C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F6A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F6B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F6BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F6C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F6D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F6E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F6EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F6F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F71C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F74C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F77C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F7A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F7AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F7B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F7C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F7D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F7DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F7E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F7F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F80C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F83C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F86C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F89C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F8A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F8B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F8C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F8CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F8D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F8E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F8F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F8FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F92C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F95C
+	voice_noise_alt 60, 0, 0, 0, 1, 7, 1 @ 848F968
 
+	.align 2
 voicegroup131:: @ 848F974
 	voice_keysplit_all voicegroup002 @ 848F974
 	voice_keysplit voicegroup003, KeySplitTable1 @ 848F980
 	voice_directsound 60, 0, DirectSoundWaveData_steinway_b_piano, 128, 204, 51, 242 @ 848F98C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F998
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F9A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F9B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F9BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F9C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F9D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F9E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F9EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848F9F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FA88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F9A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F9B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F9BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F9C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F9D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F9E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F9EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848F9F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FA88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 204, 103, 226 @ 848FA94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FAA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FAAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FAB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FAC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FAD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FADC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FAE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FAF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FB9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FBA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FBB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FBC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FBCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FBD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FBE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FBF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FBFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FC98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FCA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FCB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FCBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FCC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FCD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FCE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FCEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FCF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FD04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FD10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FD1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FD28
-	voice_square_1_alt 0, 1, 0, 2, 3, 5 @ 848FD34
-	voice_square_2_alt 3, 0, 2, 6, 5 @ 848FD40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FD4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FD58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FD64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FD70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FD7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FD88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FD94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FDA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FDAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FDB8
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 7, 9, 1 @ 848FDC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FDD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FDDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FDE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FDF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FE9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FEA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FEB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FEC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FECC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FED8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FEE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FEF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FEFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FF08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FF14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FF20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FF2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FF38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FF44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FF50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FF5C
-	voice_noise_alt 0, 0, 1, 0, 1 @ 848FF68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FAA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FAAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FAB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FAC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FAD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FAE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FAF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FB9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FBA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FBB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FBC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FBCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FBD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FBE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FBF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FBFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FC98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FCA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FCB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FCBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FCC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FCD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FCE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FCEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FCF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FD04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FD10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FD1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FD28
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 3, 5 @ 848FD34
+	voice_square_2_alt 60, 0, 3, 0, 2, 6, 5 @ 848FD40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FD4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FD58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FD64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FD70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FD7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FD88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FD94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FDA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FDAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FDB8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 7, 9, 1 @ 848FDC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FDD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FDDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FDE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FDF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FE9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FEA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FEB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FEC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FEE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FEF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FEFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FF08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FF14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FF20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FF2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FF38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FF44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FF50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FF5C
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 1 @ 848FF68
 
+	.align 2
 voicegroup132:: @ 848FF74
 	voice_keysplit_all voicegroup002 @ 848FF74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FF80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FF8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FF98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FFA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FFB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FFBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FFC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FFD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FFE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FFEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 848FFF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490004
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FF80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FF8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FF98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FFA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FFB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FFBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FFC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FFD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FFE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FFEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 848FFF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490010
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 97, 236 @ 849001C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490028
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490034
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 128, 146, 118, 137 @ 8490040
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849004C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490058
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490064
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490070
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849007C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849004C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849007C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490088
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 51, 204, 92, 226 @ 8490094
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84900A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84900AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84900B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84900C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84900D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84900DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84900E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84900F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490100
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849010C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490118
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490124
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490130
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849013C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490148
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490154
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490160
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849016C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490178
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490184
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490190
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849019C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84900A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84900AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84900B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84900C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84900D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84900DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84900E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84900F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849010C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849013C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849016C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849019C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 165, 154, 235 @ 84901A8
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84901B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84901C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84901CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84901D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84901E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84901F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84901FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84901C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84901CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84901D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84901E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84901F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84901FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490208
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8490214
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490220
 	voice_keysplit voicegroup006, KeySplitTable4 @ 849022C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490238
 	voice_keysplit voicegroup007, KeySplitTable5 @ 8490244
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490250
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849025C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490268
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490274
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490280
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849028C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490298
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84902A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84902B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84902BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84902C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84902D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849025C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849028C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84902A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84902B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84902BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84902C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84902D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 84902E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84902EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84902F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490304
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490310
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849031C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490328
-	voice_square_1_alt 0, 2, 0, 4, 2, 2 @ 8490334
-	voice_square_2_alt 3, 0, 1, 7, 5 @ 8490340
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 4, 6, 0 @ 849034C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490358
-	voice_programmable_wave_alt gProgrammableWaveData_84A328C, 0, 4, 6, 0 @ 8490364
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490370
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849037C
-	voice_square_1_alt 0, 0, 0, 4, 2, 2 @ 8490388
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490394
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84903A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84903AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84903B8
-	voice_programmable_wave_alt gProgrammableWaveData_84A31FC, 0, 2, 9, 1 @ 84903C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84903D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84903DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84903E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84903F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490400
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849040C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490418
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490424
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490430
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849043C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490448
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490454
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490460
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849046C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490478
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490484
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490490
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849049C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84904A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84904B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84904C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84904CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84904D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84904E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84904F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84904FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490508
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490514
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490520
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849052C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490538
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490544
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490550
-	voice_noise_alt 0, 0, 2, 6, 0 @ 849055C
-	voice_noise_alt 0, 0, 1, 8, 1 @ 8490568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84902EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84902F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849031C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490328
+	voice_square_1_alt 60, 0, 0, 2, 0, 4, 2, 2 @ 8490334
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 5 @ 8490340
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 4, 6, 0 @ 849034C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490358
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A328C, 0, 4, 6, 0 @ 8490364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849037C
+	voice_square_1_alt 60, 0, 0, 0, 0, 4, 2, 2 @ 8490388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84903A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84903AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84903B8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31FC, 0, 2, 9, 1 @ 84903C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84903D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84903DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84903E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84903F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849040C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849043C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849046C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849049C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84904A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84904B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84904C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84904CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84904D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84904E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84904F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84904FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849052C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490550
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 849055C
+	voice_noise_alt 60, 0, 0, 0, 1, 8, 1 @ 8490568
 
+	.align 2
 voicegroup133:: @ 8490574
 	voice_keysplit_all voicegroup002 @ 8490574
 	voice_keysplit voicegroup003, KeySplitTable1 @ 8490580
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849058C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490598
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84905A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84905B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84905BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84905C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84905D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84905E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849058C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84905A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84905B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84905BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84905C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84905D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84905E0
 	voice_directsound 60, 0, DirectSoundWaveData_ethnic_flavours_atarigane, 255, 0, 255, 0 @ 84905EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84905F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490604
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84905F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490610
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 849061C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490628
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490634
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 128, 146, 108, 137 @ 8490640
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849064C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490658
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490664
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490670
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849067C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849064C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849067C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490688
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 204, 103, 226 @ 8490694
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84906A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84906AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84906B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84906C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84906A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84906AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84906B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84906C4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127 @ 84906D0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127 @ 84906DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84906E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84906F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490700
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849070C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490718
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490724
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84906E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84906F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849070C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490730
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 255, 252, 0, 115 @ 849073C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 255, 0, 255, 127 @ 8490748
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490754
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490760
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849076C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490778
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490784
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490790
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849079C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849076C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849079C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 0, 193, 153 @ 84907A8
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84907B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84907C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84907CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84907D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84907E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84907F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84907FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84907C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84907CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84907D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84907E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84907F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84907FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490808
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8490814
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490820
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849082C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849082C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490838
 	voice_keysplit voicegroup007, KeySplitTable5 @ 8490844
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490850
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 127 @ 849085C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490868
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490874
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490880
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849088C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490898
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84908A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84908B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84908BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84908C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84908D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84908E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84908EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84908F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490904
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849088C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84908A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84908B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84908BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84908C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84908D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84908E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84908EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84908F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490910
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127 @ 849091C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490928
-	voice_square_1_alt 0, 1, 0, 1, 9, 0 @ 8490934
-	voice_square_2_alt 3, 0, 2, 9, 1 @ 8490940
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849094C
-	voice_square_2_alt 2, 1, 0, 9, 1 @ 8490958
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490964
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490970
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849097C
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8490988
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490994
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84909A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84909AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84909B8
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 0, 15, 0 @ 84909C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84909D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84909DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84909E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84909F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490A9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490AA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490AB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490AC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490ACC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490AD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490AE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490AF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490AFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490928
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 9, 0 @ 8490934
+	voice_square_2_alt 60, 0, 3, 0, 2, 9, 1 @ 8490940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849094C
+	voice_square_2_alt 60, 0, 2, 1, 0, 9, 1 @ 8490958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849097C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8490988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84909A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84909AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84909B8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 0, 15, 0 @ 84909C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84909D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84909DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84909E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84909F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490B08
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165 @ 8490B14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490B20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490B2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490B38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490B44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490B50
-	voice_noise_alt 0, 0, 2, 6, 0 @ 8490B5C
-	voice_noise_alt 0, 0, 1, 8, 1 @ 8490B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490B50
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 8490B5C
+	voice_noise_alt 60, 0, 0, 0, 1, 8, 1 @ 8490B68
 
+	.align 2
 voicegroup134:: @ 8490B74
 	voice_keysplit_all voicegroup001 @ 8490B74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490B80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490B8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490B98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490BA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490BB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490BBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490BC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490BD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490BE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490BEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490BF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490C94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490CA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490CAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490CB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490CC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490CD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490CDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490CE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490CF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490D9C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 246, 0, 226 @ 8490DA8
 	voice_keysplit voicegroup004, KeySplitTable2 @ 8490DB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490DC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490DCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490DD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490DE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490DF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490DFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490E08
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8490E14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490E20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490E2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490E38
 	voice_keysplit voicegroup007, KeySplitTable5 @ 8490E44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490E50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490E5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490E68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490E74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490E80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490E8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490E98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490EA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490EB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490EBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490EC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490ED4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490EE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490EEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490EF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490F04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490F10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490F1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490F28
-	voice_square_2_alt 2, 0, 1, 7, 1 @ 8490F34
-	voice_square_1_alt 0, 2, 0, 1, 7, 1 @ 8490F40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490F4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490F58
-	voice_square_2_alt 3, 0, 1, 7, 1 @ 8490F64
-	voice_square_1_alt 0, 3, 0, 1, 7, 1 @ 8490F70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490F7C
-	voice_programmable_wave_alt gProgrammableWaveData_84A324C, 0, 7, 15, 1 @ 8490F88
-	voice_square_1_alt 0, 2, 0, 0, 7, 1 @ 8490F94
-	voice_square_1_alt 0, 3, 0, 0, 7, 1 @ 8490FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490F28
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 1 @ 8490F34
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 1 @ 8490F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490F58
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 1 @ 8490F64
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 1 @ 8490F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490F7C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A324C, 0, 7, 15, 1 @ 8490F88
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 7, 1 @ 8490F94
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 7, 1 @ 8490FA0
 
+	.align 2
 voicegroup135:: @ 8490FAC
 	voice_keysplit_all voicegroup002 @ 8490FAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490FB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490FC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490FD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490FDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490FE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8490FF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491000
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849100C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491018
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491024
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491030
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849103C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491048
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491054
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491060
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849106C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491078
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491084
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491090
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849109C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8490FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849100C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849103C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849106C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849109C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 85, 137, 180, 204 @ 84910A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84910B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84910C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84910CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84910D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84910E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84910F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84910FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491108
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491114
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491120
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849112C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491138
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491144
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491150
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849115C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491168
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491174
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491180
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849118C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491198
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84911A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84911B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84911BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84911C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84911D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84911E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84911EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84911F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491204
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491210
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849121C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491228
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491234
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491240
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849124C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491258
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491264
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491270
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849127C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491288
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491294
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84912A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84912AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84912B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84912C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84912D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84912DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84912E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84912F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491300
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849130C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491318
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491324
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491330
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849133C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491348
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491354
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491360
-	voice_square_1_alt 0, 2, 0, 0, 9, 0 @ 849136C
-	voice_square_2_alt 2, 0, 0, 9, 0 @ 8491378
-	voice_square_1_alt 0, 0, 1, 2, 6, 0 @ 8491384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84910B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84910C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84910CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84910D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84910E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84910F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84910FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849112C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849115C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849118C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84911A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84911B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84911BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84911C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84911D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84911E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84911EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84911F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849121C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849124C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849127C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84912A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84912AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84912B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84912C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84912D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84912DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84912E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84912F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849130C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849133C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491360
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 9, 0 @ 849136C
+	voice_square_2_alt 60, 0, 2, 0, 0, 9, 0 @ 8491378
+	voice_square_1_alt 60, 0, 0, 0, 1, 2, 6, 0 @ 8491384
 
+	.align 2
 voicegroup136:: @ 8491390
 	voice_keysplit_all voicegroup002 @ 8491390
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849139C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84913A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84913B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84913C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84913CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84913D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84913E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84913F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84913FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491408
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491414
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491420
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849142C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491438
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491444
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491450
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849145C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491468
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491474
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491480
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849148C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491498
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84914A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84914B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84914BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84914C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84914D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84914E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84913A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84913B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84913C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84913CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84913D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84913E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84913F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84913FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849142C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849145C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849148C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84914A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84914B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84914BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84914C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84914D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84914E0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127 @ 84914EC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127 @ 84914F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491504
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491510
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849151C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491528
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491534
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491540
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849154C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849151C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849154C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 255, 252, 0, 115 @ 8491558
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491564
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491570
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849157C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491588
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491594
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84915A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84915AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84915B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84915C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849157C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84915A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84915AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84915B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84915C4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84915D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84915DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84915E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84915F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491600
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849160C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491618
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491624
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491630
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849163C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491648
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491654
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491660
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849166C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84915DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84915E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84915F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849160C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849163C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849166C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 127 @ 8491678
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491684
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491690
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849169C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84916A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84916B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84916C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84916CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84916D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84916E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84916F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84916FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491708
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491714
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491720
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849172C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491738
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491744
-	voice_square_2_alt 0, 0, 5, 0, 0 @ 8491750
-	voice_square_1_alt 0, 0, 0, 5, 0, 0 @ 849175C
-	voice_square_1_alt 0, 2, 2, 4, 10, 0 @ 8491768
-	voice_square_2_alt 0, 0, 5, 0, 0 @ 8491774
-	voice_square_1_alt 0, 1, 0, 5, 0, 0 @ 8491780
-	voice_square_2_alt 3, 2, 4, 10, 0 @ 849178C
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 1, 5, 0, 3 @ 8491798
-	voice_programmable_wave_alt gProgrammableWaveData_84A323C, 1, 5, 0, 3 @ 84917A4
-	voice_square_2_alt 1, 0, 1, 10, 2 @ 84917B0
-	voice_square_1_alt 0, 1, 0, 1, 10, 0 @ 84917BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84917C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84917D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84917E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84917EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84917F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491804
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491810
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849181C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491828
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491834
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491840
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849184C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491858
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491864
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491870
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849187C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491888
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491894
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84918A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84918AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84918B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84918C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84918D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84918DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84918E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84918F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491900
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849190C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491918
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491924
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491930
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849193C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491948
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491954
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491960
-	voice_noise_alt 0, 0, 0, 15, 0 @ 849196C
-	voice_noise_alt 0, 0, 2, 4, 0 @ 8491978
-	voice_noise_alt 0, 0, 1, 0, 0 @ 8491984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849169C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84916A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84916B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84916C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84916CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84916D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84916E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84916F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84916FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849172C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491744
+	voice_square_2_alt 60, 0, 0, 0, 5, 0, 0 @ 8491750
+	voice_square_1_alt 60, 0, 0, 0, 0, 5, 0, 0 @ 849175C
+	voice_square_1_alt 60, 0, 0, 2, 2, 4, 10, 0 @ 8491768
+	voice_square_2_alt 60, 0, 0, 0, 5, 0, 0 @ 8491774
+	voice_square_1_alt 60, 0, 0, 1, 0, 5, 0, 0 @ 8491780
+	voice_square_2_alt 60, 0, 3, 2, 4, 10, 0 @ 849178C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 1, 5, 0, 3 @ 8491798
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A323C, 1, 5, 0, 3 @ 84917A4
+	voice_square_2_alt 60, 0, 1, 0, 1, 10, 2 @ 84917B0
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 10, 0 @ 84917BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84917C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84917D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84917E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84917EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84917F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849181C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849184C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849187C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84918A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84918AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84918B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84918C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84918D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84918DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84918E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84918F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849190C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849193C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491960
+	voice_noise_alt 60, 0, 0, 0, 0, 15, 0 @ 849196C
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0 @ 8491978
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0 @ 8491984
 
+	.align 2
 voicegroup137:: @ 8491990
 	voice_keysplit_all voicegroup002 @ 8491990
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849199C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84919A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84919B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849199C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84919A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84919B4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 165, 180, 165 @ 84919C0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 137, 154, 165 @ 84919CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84919D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84919E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84919F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84919D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84919E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84919F0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_glockenspiel, 255, 204, 51, 242 @ 84919FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A2C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 8491A38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491A98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491AA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491AB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491ABC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491AC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491AD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491AE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491AEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491AF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491B94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491BA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491BAC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 242, 0, 242 @ 8491BB8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 0, 193, 153 @ 8491BC4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 8491BD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491BDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491BE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491BF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491C00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491C0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491C18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491C24
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8491C30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491C3C
 	voice_keysplit voicegroup006, KeySplitTable4 @ 8491C48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491C54
 	voice_keysplit voicegroup007, KeySplitTable5 @ 8491C60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491C6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491C78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491C84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491C90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491C9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491CA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491CB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491CC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491CCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491CD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491CE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491CF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491CFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491D08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491D14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491D20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491D2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491D38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491D44
-	voice_square_1_alt 0, 1, 1, 2, 3, 1 @ 8491D50
-	voice_square_2_alt 1, 1, 2, 3, 1 @ 8491D5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491D68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491D74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491D80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491D8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491D98
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 2, 4, 1 @ 8491DA4
-	voice_programmable_wave_alt gProgrammableWaveData_84A323C, 0, 2, 4, 1 @ 8491DB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491DBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491DC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491DD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491DE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491DEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491DF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491E94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491EA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491EAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491EB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491EC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491ED0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491EDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491EE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491EF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491F00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491F0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491F18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491F24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491F30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491F3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491F48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491F54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491F60
-	voice_noise_alt 0, 0, 0, 15, 0 @ 8491F6C
-	voice_noise_alt 0, 0, 2, 4, 0 @ 8491F78
-	voice_noise_alt 0, 0, 1, 0, 1 @ 8491F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491D44
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 3, 1 @ 8491D50
+	voice_square_2_alt 60, 0, 1, 1, 2, 3, 1 @ 8491D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491D98
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 2, 4, 1 @ 8491DA4
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A323C, 0, 2, 4, 1 @ 8491DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491F18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491F60
+	voice_noise_alt 60, 0, 0, 0, 0, 15, 0 @ 8491F6C
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0 @ 8491F78
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 1 @ 8491F84
 
+	.align 2
 voicegroup138:: @ 8491F90
 	voice_keysplit_all voicegroup002 @ 8491F90
 	voice_keysplit voicegroup003, KeySplitTable1 @ 8491F9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491FA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491FB4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226 @ 8491FC0
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 204, 77, 246 @ 8491FCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491FD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491FE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491FF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8491FFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492008
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492014
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492020
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849202C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492038
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492044
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8491FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849202C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492050
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 76, 133, 137 @ 849205C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492068
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492074
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492080
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 64, 188, 108, 165 @ 849208C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492098
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84920A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84920A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 249, 25, 127 @ 84920B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84920BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84920C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84920D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84920E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84920EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84920F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492104
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492110
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849211C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492128
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492134
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492140
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849214C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492158
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492164
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492170
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849217C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492188
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492194
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84921A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84921AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84920BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84920C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84920D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84920E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84920EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84920F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849211C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849214C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849217C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84921A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84921AC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 246, 0, 235 @ 84921B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84921C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84921C4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84921D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84921DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84921E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84921F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492200
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849220C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492218
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84921DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84921E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84921F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849220C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492224
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8492230
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849223C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492248
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492254
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492260
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849226C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492278
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492284
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492290
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849229C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84922A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84922B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84922C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84922CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84922D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84922E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84922F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849223C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849226C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849229C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84922A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84922B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84922C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84922CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84922D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84922E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84922F0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 84922FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492308
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492314
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492320
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849232C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492338
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492344
-	voice_square_1_alt 0, 0, 0, 2, 5, 2 @ 8492350
-	voice_square_2_alt 3, 0, 1, 6, 3 @ 849235C
-	voice_square_2_alt 0, 0, 2, 6, 5 @ 8492368
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492374
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492380
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849238C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492398
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84923A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84923B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84923BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84923C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84923D4
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 0, 12, 0 @ 84923E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84923EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84923F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492404
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492410
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849241C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492428
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492434
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492440
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849244C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492458
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492464
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492470
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849247C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492488
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492494
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84924A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84924AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84924B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84924C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84924D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84924DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84924E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84924F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492500
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849250C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492518
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492524
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492530
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849253C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492548
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492554
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492560
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849256C
-	voice_noise_alt 0, 0, 2, 6, 0 @ 8492578
-	voice_noise_alt 0, 0, 1, 6, 0 @ 8492584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849232C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492344
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 5, 2 @ 8492350
+	voice_square_2_alt 60, 0, 3, 0, 1, 6, 3 @ 849235C
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5 @ 8492368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849238C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84923A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84923B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84923BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84923C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84923D4
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 0, 12, 0 @ 84923E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84923EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84923F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849241C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849244C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849247C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84924A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84924AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84924B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84924C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84924D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84924DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84924E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84924F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849250C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849253C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849256C
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 8492578
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0 @ 8492584
 
+	.align 2
 voicegroup139:: @ 8492590
 	voice_keysplit_all voicegroup002 @ 8492590
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849259C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84925A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84925B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84925C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84925CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84925D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84925E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84925F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84925A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84925B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84925C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84925CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84925D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84925E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84925F0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_glockenspiel, 255, 165, 51, 242 @ 84925FC
 	voice_directsound 60, 0, DirectSoundWaveData_ethnic_flavours_atarigane, 255, 0, 255, 0 @ 8492608
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492614
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492620
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_xylophone, 255, 235, 0, 204 @ 849262C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 8492638
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492644
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492650
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 128, 127, 103, 201 @ 849265C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492668
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492674
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492680
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 37, 127, 77, 165 @ 849268C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492698
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84926A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84926A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 51, 204, 92, 226 @ 84926B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84926BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84926C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84926D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84926E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84926EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84926F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492704
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492710
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849271C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492728
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492734
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492740
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849274C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492758
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492764
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492770
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849277C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492788
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492794
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84927A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84927AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84926BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84926C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84926D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84926E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84926EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84926F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849271C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849274C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849277C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84927A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84927AC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 242, 51, 226 @ 84927B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84927C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84927C4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84927D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84927DC
-	voice_square_1_alt 0, 2, 0, 2, 3, 1 @ 84927E8
-	voice_square_2_alt 3, 0, 2, 7, 2 @ 84927F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492800
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849280C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492818
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492824
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492830
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849283C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84927DC
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 3, 1 @ 84927E8
+	voice_square_2_alt 60, 0, 3, 0, 2, 7, 2 @ 84927F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849280C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849283C
 	voice_keysplit voicegroup006, KeySplitTable4 @ 8492848
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492854
 	voice_keysplit voicegroup007, KeySplitTable5 @ 8492860
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849286C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492878
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492884
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492890
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849289C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84928A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84928B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84928C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84928CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84928D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84928E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84928F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849286C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849289C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84928A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84928B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84928C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84928CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84928D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84928E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84928F0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 0, 255, 165 @ 84928FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492908
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492914
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492920
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849292C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849292C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127 @ 8492938
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492944
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492950
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849295C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492968
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492974
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492980
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849298C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492998
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84929A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84929B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84929BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84929C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84929D4
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84929E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84929EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84929F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492A94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492AA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492AAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492AB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492AC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492AD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492ADC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492AE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492AF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492B00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492B0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492B18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492B24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492B30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492B3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492B48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492B54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492B60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492B6C
-	voice_noise_alt 0, 0, 1, 6, 1 @ 8492B78
-	voice_noise_alt 0, 0, 1, 6, 1 @ 8492B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849295C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849298C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84929A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84929B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84929BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84929C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84929D4
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84929E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84929EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84929F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492B6C
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1 @ 8492B78
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1 @ 8492B84
 
+	.align 2
 voicegroup140:: @ 8492B90
 	voice_keysplit_all voicegroup001 @ 8492B90
-	voice_square_1 0, 2, 0, 2, 3, 1 @ 8492B9C
-	voice_square_2_alt 2, 0, 2, 3, 1 @ 8492BA8
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8492BB4
+	voice_square_1 60, 0, 0, 2, 0, 2, 3, 1 @ 8492B9C
+	voice_square_2_alt 60, 0, 2, 0, 2, 3, 1 @ 8492BA8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8492BB4
 
+	.align 2
 voicegroup141:: @ 8492BC0
 	voice_keysplit_all voicegroup002 @ 8492BC0
 	voice_keysplit voicegroup003, KeySplitTable1 @ 8492BCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492BD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492BE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492BF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492BFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492C08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492C14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492C20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492C2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492C38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492C44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492C50
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_xylophone, 255, 235, 0, 204 @ 8492C5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492C68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492C74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492C80
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 76, 133, 137 @ 8492C8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492C98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492CA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492CB0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 64, 188, 108, 165 @ 8492CBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492CC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492CD4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 85, 249, 25, 127 @ 8492CE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492CEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492CF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492D94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492DA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492DAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492DB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492DC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492DD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492DDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492DE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492DF4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 8492E00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E54
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8492E60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492E9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492EA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492EB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492EC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492ECC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492ED8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492EE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492EF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492EFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492F08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492F14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492F20
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 0, 255, 165 @ 8492F2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492F38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492F44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492F50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492F5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492F68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492F74
-	voice_square_1_alt 0, 0, 0, 2, 5, 2 @ 8492F80
-	voice_square_2_alt 3, 0, 2, 7, 3 @ 8492F8C
-	voice_square_2_alt 2, 0, 2, 6, 5 @ 8492F98
-	voice_programmable_wave_alt gProgrammableWaveData_84A31FC, 1, 7, 0, 6 @ 8492FA4
-	voice_square_1_alt 0, 1, 0, 2, 4, 2 @ 8492FB0
-	voice_programmable_wave_alt gProgrammableWaveData_84A320C, 0, 2, 9, 0 @ 8492FBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492FC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492FD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492FE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492FEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8492FF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493004
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493010
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849301C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493028
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493034
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493040
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849304C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493058
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493064
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493070
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849307C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493088
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493094
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84930A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84930AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84930B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84930C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84930D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84930DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84930E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84930F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493100
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849310C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493118
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493124
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493130
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849313C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493148
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493154
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493160
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849316C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493178
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493184
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493190
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849319C
-	voice_noise_alt 0, 0, 2, 6, 0 @ 84931A8
-	voice_noise_alt 0, 0, 1, 6, 0 @ 84931B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492F74
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 5, 2 @ 8492F80
+	voice_square_2_alt 60, 0, 3, 0, 2, 7, 3 @ 8492F8C
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 5 @ 8492F98
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31FC, 1, 7, 0, 6 @ 8492FA4
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 4, 2 @ 8492FB0
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A320C, 0, 2, 9, 0 @ 8492FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8492FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849301C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849304C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849307C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84930A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84930AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84930B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84930C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84930D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84930DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84930E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84930F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849310C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849313C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849316C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849319C
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 84931A8
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0 @ 84931B4
 
+	.align 2
 voicegroup142:: @ 84931C0
 	voice_keysplit_all voicegroup002 @ 84931C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84931CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84931D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84931E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84931F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84931FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493208
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493214
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493220
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849322C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493238
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493244
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493250
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849325C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493268
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493274
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84931CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84931D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84931E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84931F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84931FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849322C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849325C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493280
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 64, 188, 128, 201 @ 849328C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493298
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84932A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84932B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84932BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84932C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84932D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84932A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84932B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84932BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84932C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84932D4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 64, 195, 103, 220 @ 84932E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84932EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84932F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493304
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84932EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84932F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493310
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 128, 195, 72, 127 @ 849331C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 85, 188, 103, 160 @ 8493328
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493334
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493340
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849334C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493358
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493364
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493370
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849337C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849334C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849337C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 128, 188, 77, 115 @ 8493388
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493394
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84933A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84933AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84933B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84933C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84933D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84933DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84933E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84933F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493400
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849340C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493418
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493424
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493430
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849343C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493448
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493454
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493460
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849346C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493478
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493484
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493490
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849349C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84933A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84933AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84933B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84933C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84933D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84933DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84933E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84933F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849340C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849343C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849346C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849349C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 175, 154, 127 @ 84934A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84934B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84934C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84934CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84934D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84934E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84934F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84934FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493508
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493514
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493520
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849352C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493538
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493544
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493550
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849355C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493568
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493574
-	voice_square_1_alt 0, 2, 0, 2, 6, 4 @ 8493580
-	voice_square_2_alt 2, 0, 2, 5, 5 @ 849358C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493598
-	voice_programmable_wave_alt gProgrammableWaveData_84A326C, 0, 7, 15, 0 @ 84935A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84934B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84934C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84934CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84934D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84934E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84934F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84934FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849352C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849355C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493574
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 6, 4 @ 8493580
+	voice_square_2_alt 60, 0, 2, 0, 2, 5, 5 @ 849358C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493598
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A326C, 0, 7, 15, 0 @ 84935A4
 
+	.align 2
 voicegroup143:: @ 84935B0
 	voice_keysplit_all voicegroup002 @ 84935B0
 	voice_keysplit voicegroup003, KeySplitTable1 @ 84935BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84935C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84935D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84935E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84935EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84935F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493604
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493610
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849361C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493628
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493634
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493640
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849364C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493658
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493664
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84935C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84935D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84935E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84935EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84935F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849361C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849364C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493670
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 128, 160, 123, 165 @ 849367C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493688
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493694
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84936A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84936AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84936B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84936C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84936A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84936AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84936B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84936C4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 249, 25, 0 @ 84936D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84936DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84936E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84936F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493700
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849370C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493718
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493724
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493730
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849373C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493748
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493754
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493760
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849376C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493778
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493784
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493790
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849379C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84937A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84937B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84937C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84937CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84937D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84937E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84936DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84936E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84936F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849370C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849373C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849376C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849379C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84937A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84937B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84937C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84937CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84937D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84937E4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84937F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84937FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493808
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493814
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493820
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849382C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493838
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493844
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493850
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849385C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493868
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493874
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493880
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849388C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493898
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84938A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84938B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84938BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84938C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84938D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84938E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84938EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84938F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493904
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493910
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849391C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493928
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493934
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493940
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849394C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493958
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493964
-	voice_square_2_alt 3, 0, 2, 3, 2 @ 8493970
-	voice_square_1_alt 0, 2, 0, 2, 3, 1 @ 849397C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493988
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8493994
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84939A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84939AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84939B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84939C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84939D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84939DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84939E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84939F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493A9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493AA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493AB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493AC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493ACC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493AD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493AE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493AF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493AFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493B8C
-	voice_noise_alt 0, 0, 1, 9, 0 @ 8493B98
-	voice_noise_alt 0, 0, 1, 6, 1 @ 8493BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84937FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849382C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849385C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849388C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84938A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84938B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84938BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84938C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84938D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84938E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84938EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84938F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849391C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849394C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493964
+	voice_square_2_alt 60, 0, 3, 0, 2, 3, 2 @ 8493970
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 3, 1 @ 849397C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493988
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8493994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84939A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84939AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84939B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84939C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84939D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84939DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84939E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84939F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493B8C
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 0 @ 8493B98
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1 @ 8493BA4
 
+	.align 2
 voicegroup144:: @ 8493BB0
 	voice_keysplit_all voicegroup002 @ 8493BB0
 	voice_keysplit voicegroup003, KeySplitTable1 @ 8493BBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493BC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493BD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493BE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493BEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493BF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493C04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493C10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493C1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493C28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493C34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493C40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493C4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493C58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493C64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493C70
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 85, 188, 92, 165 @ 8493C7C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 85, 127, 180, 165 @ 8493C88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493C94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493CA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493CAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493CB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493CC4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 51, 204, 92, 226 @ 8493CD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493CDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493CE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493CF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D48
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 253, 0, 216 @ 8493D54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D6C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 255, 252, 0, 115 @ 8493D78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493D9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493DA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493DB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493DC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493DCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493DD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493DE4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 8493DF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493DFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493E98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493EA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493EB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493EBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493EC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493ED4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493EE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493EEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493EF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493F04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493F10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493F1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493F28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493F34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493F40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493F4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493F58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493F64
-	voice_square_2_alt 3, 0, 2, 4, 2 @ 8493F70
-	voice_square_2_alt 1, 0, 2, 4, 3 @ 8493F7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493F88
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8493F94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493FA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493FAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493FB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493FC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493FD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493FDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493FE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8493FF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494000
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849400C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494018
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494024
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494030
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849403C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494048
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494054
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494060
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849406C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494078
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494084
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494090
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849409C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84940A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84940B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84940C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84940CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84940D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84940E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84940F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84940FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494108
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494114
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494120
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849412C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494138
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494144
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494150
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849415C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494168
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494174
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494180
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849418C
-	voice_noise_alt 0, 0, 1, 9, 0 @ 8494198
-	voice_noise_alt 0, 0, 1, 6, 0 @ 84941A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493F64
+	voice_square_2_alt 60, 0, 3, 0, 2, 4, 2 @ 8493F70
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 3 @ 8493F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493F88
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8493F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8493FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849400C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849403C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849406C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849409C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84940A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84940B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84940C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84940CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84940D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84940E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84940F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84940FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849412C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849415C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849418C
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 0 @ 8494198
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0 @ 84941A4
 
+	.align 2
 voicegroup145:: @ 84941B0
 	voice_keysplit_all voicegroup002 @ 84941B0
 	voice_keysplit voicegroup003, KeySplitTable1 @ 84941BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84941C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84941D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84941C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84941D4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226 @ 84941E0
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 204, 77, 246 @ 84941EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84941F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494204
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494210
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849421C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494228
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494234
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494240
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849424C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494258
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494264
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84941F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849421C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849424C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494270
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 76, 133, 137 @ 849427C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494288
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494294
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84942A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84942A0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 64, 188, 108, 165 @ 84942AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84942B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84942C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84942B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84942C4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 249, 25, 127 @ 84942D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84942DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84942E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84942F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494300
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849430C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494318
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494324
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494330
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849433C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494348
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494354
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494360
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849436C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494378
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494384
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494390
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849439C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84943A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84943B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84943C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84943CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84942DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84942E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84942F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849430C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849433C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849436C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849439C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84943A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84943B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84943C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84943CC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 246, 0, 235 @ 84943D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84943E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84943E4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84943F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84943FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494408
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494414
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494420
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849442C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494438
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84943FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849442C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494444
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8494450
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849445C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494468
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494474
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494480
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849448C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494498
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84944A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84944B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84944BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84944C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84944D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84944E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84944EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84944F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494504
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849445C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849448C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84944A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84944B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84944BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84944C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84944D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84944E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84944EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84944F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494510
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 849451C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494528
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494534
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494540
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849454C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494558
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494564
-	voice_square_1_alt 0, 0, 0, 2, 5, 2 @ 8494570
-	voice_square_2_alt 3, 0, 0, 9, 0 @ 849457C
-	voice_square_2_alt 0, 0, 2, 6, 5 @ 8494588
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494594
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84945A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84945AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84945B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84945C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84945D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84945DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84945E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84945F4
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 0, 12, 0 @ 8494600
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849460C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494618
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494624
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494630
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849463C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494648
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494654
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494660
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849466C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494678
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494684
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494690
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849469C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84946A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84946B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84946C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84946CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84946D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84946E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84946F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84946FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494708
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494714
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494720
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849472C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494738
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494744
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494750
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849475C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494768
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494774
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494780
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849478C
-	voice_noise_alt 0, 0, 2, 6, 0 @ 8494798
-	voice_noise_alt 0, 0, 1, 6, 0 @ 84947A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849454C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494564
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 5, 2 @ 8494570
+	voice_square_2_alt 60, 0, 3, 0, 0, 9, 0 @ 849457C
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5 @ 8494588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84945A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84945AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84945B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84945C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84945D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84945DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84945E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84945F4
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 0, 12, 0 @ 8494600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849460C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849463C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849466C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849469C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84946A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84946B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84946C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84946CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84946D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84946E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84946F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84946FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849472C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849475C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849478C
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 8494798
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0 @ 84947A4
 
+	.align 2
 voicegroup146:: @ 84947B0
 	voice_keysplit_all voicegroup002 @ 84947B0
 	voice_directsound 60, 0, DirectSoundWaveData_steinway_b_piano, 255, 165, 103, 235 @ 84947BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84947C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84947D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84947E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84947EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84947F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494804
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494810
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849481C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494828
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494834
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84947C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84947D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84947E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84947EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84947F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849481C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494840
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_xylophone, 255, 235, 0, 204 @ 849484C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494858
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494864
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494870
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849487C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494888
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494894
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84948A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84948AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84948B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84948C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849487C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84948A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84948AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84948B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84948C4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 85, 249, 25, 226 @ 84948D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84948DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84948E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84948F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494900
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849490C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494918
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494924
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494930
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849493C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494948
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494954
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494960
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849496C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494978
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494984
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494990
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849499C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84949A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84949B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84949C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84949CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84949D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84949E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84948DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84948E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84948F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849490C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849493C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849496C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849499C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84949A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84949B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84949C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84949CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84949D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84949E4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84949F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84949FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494A98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494AA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494AB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494ABC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494AC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494AD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494AE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494AEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494AF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494B04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494B10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494B1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494B28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494B34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494B40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84949FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494B4C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 43, 76, 103, 216 @ 8494B58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494B64
-	voice_square_2_alt 2, 0, 2, 4, 4 @ 8494B70
-	voice_square_1_alt 0, 2, 0, 0, 15, 0 @ 8494B7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494B88
-	voice_square_2_alt 2, 0, 0, 15, 0 @ 8494B94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494BA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494BAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494BB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494BC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494BD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494BDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494BE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494BF4
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 8494C00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494C9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494CA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494CB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494CC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494CCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494CD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494CE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494CF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494CFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494D8C
-	voice_noise_alt 0, 0, 1, 9, 0 @ 8494D98
-	voice_noise_alt 0, 0, 1, 6, 2 @ 8494DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494B64
+	voice_square_2_alt 60, 0, 2, 0, 2, 4, 4 @ 8494B70
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 15, 0 @ 8494B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494B88
+	voice_square_2_alt 60, 0, 2, 0, 0, 15, 0 @ 8494B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494BF4
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 8494C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494D8C
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 0 @ 8494D98
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 2 @ 8494DA4
 
+	.align 2
 voicegroup147:: @ 8494DB0
 	voice_keysplit_all voicegroup001 @ 8494DB0
 	voice_keysplit voicegroup003, KeySplitTable1 @ 8494DBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494DC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494DD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494DE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494DEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494DF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494E94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494EA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494EAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494EB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494EC4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 64, 249, 25, 226 @ 8494ED0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494EDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494EE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494EF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494F9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494FA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494FB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494FC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494FCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494FD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494FE4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 8494FF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8494FFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495008
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495014
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495020
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849502C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495038
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495044
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495050
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849505C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495068
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495074
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495080
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849508C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495098
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84950A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84950B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84950BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84950C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84950D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84950E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84950EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84950F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495104
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495110
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849511C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495128
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495134
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495140
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849514C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495158
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495164
-	voice_square_1_alt 0, 2, 0, 0, 6, 1 @ 8495170
-	voice_square_2_alt 2, 0, 0, 6, 1 @ 849517C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495188
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 2, 4, 2 @ 8495194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8494FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849502C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849505C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849508C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84950A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84950B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84950BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84950C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84950D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84950E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84950EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84950F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849511C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849514C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495164
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 6, 1 @ 8495170
+	voice_square_2_alt 60, 0, 2, 0, 0, 6, 1 @ 849517C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495188
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 2, 4, 2 @ 8495194
 
+	.align 2
 voicegroup148:: @ 84951A0
 	voice_keysplit_all voicegroup002 @ 84951A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84951AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84951B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84951C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84951D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84951DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84951E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84951F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495200
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849520C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495218
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495224
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84951AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84951B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84951C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84951D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84951DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84951E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84951F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849520C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495230
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 255, 226, 0, 127 @ 849523C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 8495248
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495254
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495260
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849526C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495278
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495284
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495290
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849529C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84952A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84952B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84952C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84952CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84952D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84952E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84952F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84952FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495308
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495314
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495320
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849532C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495338
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495344
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495350
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849535C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849526C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849529C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84952A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84952B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84952C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84952CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84952D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84952E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84952F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84952FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849532C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849535C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495368
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 255, 0, 255, 127 @ 8495374
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495380
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849538C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495398
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84953A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84953B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84953BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84953C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84953D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849538C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84953A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84953B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84953BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84953C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84953D4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84953E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84953EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84953F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495404
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495410
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849541C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495428
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495434
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495440
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849544C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84953EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84953F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849541C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849544C
 	voice_keysplit voicegroup006, KeySplitTable4 @ 8495458
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495464
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495470
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849547C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495488
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495494
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84954A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84954AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84954B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84954C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84954D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84954DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84954E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84954F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495500
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849550C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495518
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495524
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495530
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849553C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495548
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495554
-	voice_square_1_alt 0, 2, 0, 0, 12, 0 @ 8495560
-	voice_square_2_alt 2, 0, 0, 12, 0 @ 849556C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495578
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495584
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495590
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849559C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84955A8
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84955B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84955C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84955CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84955D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84955E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84955F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84955FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495608
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495614
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495620
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849562C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495638
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495644
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495650
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849565C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495668
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495674
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495680
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849568C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495698
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84956A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84956B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84956BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84956C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84956D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84956E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84956EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84956F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495704
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495710
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849571C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495728
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495734
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495740
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849574C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495758
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495764
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495770
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849577C
-	voice_noise_alt 0, 0, 3, 5, 2 @ 8495788
-	voice_noise_alt 0, 0, 1, 6, 5 @ 8495794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849547C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84954A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84954AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84954B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84954C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84954D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84954DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84954E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84954F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849550C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849553C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495554
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 12, 0 @ 8495560
+	voice_square_2_alt 60, 0, 2, 0, 0, 12, 0 @ 849556C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849559C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84955A8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84955B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84955C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84955CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84955D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84955E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84955F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84955FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849562C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849565C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849568C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84956A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84956B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84956BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84956C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84956D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84956E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84956EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84956F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849571C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849574C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849577C
+	voice_noise_alt 60, 0, 0, 0, 3, 5, 2 @ 8495788
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 5 @ 8495794
 
+	.align 2
 voicegroup149:: @ 84957A0
 	voice_keysplit_all voicegroup190 @ 84957A0
 	voice_keysplit voicegroup003, KeySplitTable1 @ 84957AC
-	voice_square_1_alt 0, 2, 0, 0, 12, 0 @ 84957B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84957C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84957D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84957DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84957E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84957F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495800
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 12, 0 @ 84957B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84957C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84957D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84957DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84957E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84957F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495800
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_glockenspiel, 255, 165, 51, 242 @ 849580C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495818
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495824
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495830
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_xylophone, 255, 235, 0, 204 @ 849583C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 8495848
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495854
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495860
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849586C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495878
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495884
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495890
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849589C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84958A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84958B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84958C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84958CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84958D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84958E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84958F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84958FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495908
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495914
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495920
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849592C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495938
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495944
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495950
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849595C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495968
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495974
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495980
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849598C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495998
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84959A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84959B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84959BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849586C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849589C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84958A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84958B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84958C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84958CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84958D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84958E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84958F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84958FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849592C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849595C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849598C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84959A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84959B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84959BC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 246, 0, 235 @ 84959C8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 165, 154, 153 @ 84959D4
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84959E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84959EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84959F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495A04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495A10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495A1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495A28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84959EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84959F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495A34
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8495A40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495A4C
 	voice_keysplit voicegroup006, KeySplitTable4 @ 8495A58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495A64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495A64
 	voice_keysplit voicegroup007, KeySplitTable5 @ 8495A70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495A7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495A88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495A94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495AA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495AAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495AB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495AC4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_oboe, 43, 188, 103, 165 @ 8495AD0
 	voice_directsound 60, 0, DirectSoundWaveData_unused_sd90_oboe, 43, 165, 103, 165 @ 8495ADC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495AE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495AF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495B00
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 8495B0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495B18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495B24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495B30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495B3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495B48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495B54
-	voice_square_1_alt 0, 1, 1, 2, 3, 1 @ 8495B60
-	voice_square_2_alt 1, 0, 2, 4, 2 @ 8495B6C
-	voice_square_1_alt 0, 1, 0, 2, 6, 1 @ 8495B78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495B84
-	voice_square_1_alt 0, 0, 0, 2, 3, 1 @ 8495B90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495B9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495BA8
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8495BB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495BC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495BCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495BD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495BE4
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 8495BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495B54
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 3, 1 @ 8495B60
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 2 @ 8495B6C
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 6, 1 @ 8495B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495B84
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 3, 1 @ 8495B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495BA8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8495BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495BE4
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 8495BF0
 
+	.align 2
 voicegroup150:: @ 8495BFC
 	voice_keysplit_all voicegroup002 @ 8495BFC
 	voice_directsound 60, 0, DirectSoundWaveData_steinway_b_piano, 255, 165, 103, 235 @ 8495C08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495C98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495CA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495CB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495CBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495CC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495CD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495CE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495CEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495CF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495D94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495DA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495DAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495DB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495DC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495DD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495DDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495DE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495DF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495E9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495EA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495EB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495EC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495ECC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495ED8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495EE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495EF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495EFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495EA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495F98
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 85, 204, 77, 127 @ 8495FA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495FB0
-	voice_square_2_alt 1, 0, 1, 4, 6 @ 8495FBC
-	voice_square_1_alt 0, 1, 0, 2, 4, 5 @ 8495FC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495FD4
-	voice_programmable_wave_alt gProgrammableWaveData_84A31FC, 0, 7, 15, 0 @ 8495FE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495FEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8495FF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496004
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496010
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849601C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496028
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496034
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496040
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849604C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496058
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496064
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496070
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849607C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496088
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496094
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84960A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84960AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84960B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84960C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84960D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84960DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84960E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84960F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496100
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849610C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496118
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496124
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496130
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849613C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496148
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496154
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496160
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849616C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496178
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496184
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496190
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849619C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84961A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84961B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84961C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84961CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84961D8
-	voice_noise_alt 0, 0, 2, 4, 0 @ 84961E4
-	voice_noise_alt 0, 0, 1, 0, 0 @ 84961F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495FB0
+	voice_square_2_alt 60, 0, 1, 0, 1, 4, 6 @ 8495FBC
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 4, 5 @ 8495FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495FD4
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31FC, 0, 7, 15, 0 @ 8495FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8495FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849601C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849604C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849607C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84960A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84960AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84960B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84960C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84960D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84960DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84960E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84960F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849610C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849613C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849616C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849619C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84961A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84961B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84961C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84961CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84961D8
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0 @ 84961E4
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0 @ 84961F0
 
+	.align 2
 voicegroup151:: @ 84961FC
 	voice_keysplit_all voicegroup002 @ 84961FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496208
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496214
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496220
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849622C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496238
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496244
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496250
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849625C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496268
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496274
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496280
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849628C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849622C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849625C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849628C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496298
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 84962A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84962B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84962BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84962C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84962D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84962E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84962EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84962F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496304
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496310
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849631C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496328
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496334
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496340
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849634C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496358
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496364
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496370
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849637C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496388
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496394
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84963A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84963AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84963B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84963C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84963D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84963DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84963E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84963F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496400
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849640C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496418
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84962B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84962BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84962C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84962D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84962E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84962EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84962F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849631C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849634C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849637C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84963A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84963AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84963B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84963C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84963D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84963DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84963E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84963F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849640C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496424
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 0, 193, 127 @ 8496430
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849643C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496448
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496454
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496460
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849646C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496478
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496484
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849646C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496490
 	voice_keysplit voicegroup005, KeySplitTable3 @ 849649C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84964A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84964A8
 	voice_keysplit voicegroup006, KeySplitTable4 @ 84964B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84964C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84964C0
 	voice_keysplit voicegroup007, KeySplitTable5 @ 84964CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84964D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84964E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84964F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84964FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496508
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496514
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496520
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849652C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496538
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496544
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496550
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849655C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496568
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496574
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496580
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849658C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496598
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84965A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84965B0
-	voice_square_1_alt 0, 1, 1, 2, 3, 1 @ 84965BC
-	voice_square_2_alt 1, 0, 2, 4, 2 @ 84965C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84965D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84965E0
-	voice_square_1_alt 0, 0, 0, 2, 3, 1 @ 84965EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84965F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496604
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8496610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84964D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84964E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84964F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84964FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849652C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849655C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849658C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84965A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84965B0
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 3, 1 @ 84965BC
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 2 @ 84965C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84965D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84965E0
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 3, 1 @ 84965EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84965F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496604
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8496610
 
+	.align 2
 voicegroup152:: @ 849661C
 	voice_keysplit_all voicegroup002 @ 849661C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496628
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496634
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496640
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849664C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496658
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496664
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496670
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849667C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496688
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496694
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84966A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84966AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84966B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849664C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849667C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84966A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84966AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84966B8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 97, 236 @ 84966C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84966D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84966DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84966D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84966DC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 128, 160, 175, 165 @ 84966E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84966F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496700
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849670C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496718
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496724
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84966F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849670C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496730
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 165, 128, 204 @ 849673C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496748
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496754
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496760
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849676C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496778
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496784
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496790
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849679C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84967A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84967B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84967C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84967CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84967D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84967E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84967F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84967FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496808
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496814
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496820
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849682C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496838
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849676C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849679C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84967A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84967B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84967C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84967CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84967D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84967E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84967F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84967FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849682C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496844
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 127, 154, 235 @ 8496850
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849685C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496868
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496874
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496880
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849688C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496898
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84968A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84968B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849688C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84968A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84968B0
 	voice_keysplit voicegroup005, KeySplitTable3 @ 84968BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84968C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84968C8
 	voice_keysplit voicegroup006, KeySplitTable4 @ 84968D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84968E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84968E0
 	voice_keysplit voicegroup007, KeySplitTable5 @ 84968EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84968F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496904
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496910
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849691C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496928
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496934
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496940
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849694C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496958
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496964
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496970
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849697C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496988
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496994
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84969A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84969AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84969B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84969C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84969D0
-	voice_square_1_alt 0, 2, 0, 4, 2, 1 @ 84969DC
-	voice_square_2_alt 3, 0, 1, 5, 2 @ 84969E8
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 4, 6, 0 @ 84969F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496A00
-	voice_programmable_wave_alt gProgrammableWaveData_84A328C, 0, 4, 6, 0 @ 8496A0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496A18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496A24
-	voice_square_1_alt 0, 1, 0, 2, 4, 1 @ 8496A30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496A3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496A48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496A54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496A60
-	voice_programmable_wave_alt gProgrammableWaveData_84A31FC, 0, 2, 9, 1 @ 8496A6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496A78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496A84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496A90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496A9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496AA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496AB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496AC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496ACC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496AD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496AE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496AF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496AFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496B98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496BA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496BB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496BBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496BC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496BD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496BE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496BEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496BF8
-	voice_noise_alt 0, 0, 2, 6, 0 @ 8496C04
-	voice_noise_alt 0, 0, 1, 6, 1 @ 8496C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84968F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849691C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849694C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849697C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84969A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84969AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84969B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84969C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84969D0
+	voice_square_1_alt 60, 0, 0, 2, 0, 4, 2, 1 @ 84969DC
+	voice_square_2_alt 60, 0, 3, 0, 1, 5, 2 @ 84969E8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 4, 6, 0 @ 84969F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496A00
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A328C, 0, 4, 6, 0 @ 8496A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496A24
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 4, 1 @ 8496A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496A60
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31FC, 0, 2, 9, 1 @ 8496A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496BF8
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 8496C04
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1 @ 8496C10
 
+	.align 2
 voicegroup153:: @ 8496C1C
 	voice_keysplit_all voicegroup002 @ 8496C1C
 	voice_keysplit voicegroup003, KeySplitTable1 @ 8496C28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496C34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496C40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496C4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496C58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496C64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496C70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496C7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496C88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496C94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496CA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496CAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496C7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496CB8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 97, 236 @ 8496CC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496CD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496CDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496CE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496CF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496D9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496DA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496DB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496DC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496DCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496DD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496DE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496DF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496DFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496E08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496E14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496E20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496E2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496E38
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 246, 0, 235 @ 8496E44
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 127, 154, 235 @ 8496E50
 	voice_keysplit voicegroup004, KeySplitTable2 @ 8496E5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496E68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496E74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496E80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496E8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496E98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496EA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496EB0
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8496EBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496EC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496EC8
 	voice_keysplit voicegroup006, KeySplitTable4 @ 8496ED4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496EE0
 	voice_keysplit voicegroup007, KeySplitTable5 @ 8496EEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496EF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F7C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 8496F88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496F94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496FA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496FAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496FB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496FC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8496FD0
-	voice_square_1_alt 0, 1, 0, 3, 5, 2 @ 8496FDC
-	voice_square_2_alt 3, 0, 3, 4, 2 @ 8496FE8
-	voice_square_2_alt 0, 0, 2, 6, 5 @ 8496FF4
-	voice_square_1_alt 0, 0, 0, 1, 6, 2 @ 8497000
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849700C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497018
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497024
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497030
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849703C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497048
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497054
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497060
-	voice_programmable_wave_alt gProgrammableWaveData_84A325C, 0, 1, 12, 0 @ 849706C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497078
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497084
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497090
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849709C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84970A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84970B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84970C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84970CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84970D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84970E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84970F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84970FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497108
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497114
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497120
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849712C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497138
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497144
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497150
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849715C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497168
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497174
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497180
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849718C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497198
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84971A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84971B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84971BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84971C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84971D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84971E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84971EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84971F8
-	voice_noise_alt 0, 0, 2, 6, 0 @ 8497204
-	voice_noise_alt 0, 0, 1, 6, 2 @ 8497210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8496FD0
+	voice_square_1_alt 60, 0, 0, 1, 0, 3, 5, 2 @ 8496FDC
+	voice_square_2_alt 60, 0, 3, 0, 3, 4, 2 @ 8496FE8
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5 @ 8496FF4
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 6, 2 @ 8497000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849700C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849703C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497060
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A325C, 0, 1, 12, 0 @ 849706C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849709C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84970A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84970B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84970C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84970CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84970D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84970E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84970F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84970FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849712C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849715C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849718C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84971A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84971B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84971BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84971C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84971D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84971E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84971EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84971F8
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 8497204
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 2 @ 8497210
 
+	.align 2
 voicegroup154:: @ 849721C
 	voice_keysplit_all voicegroup002 @ 849721C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497228
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497234
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497240
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165 @ 849724C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497258
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497264
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497270
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849727C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497288
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497294
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84972A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84972AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84972B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849727C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84972A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84972AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84972B8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 97, 236 @ 84972C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84972D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84972DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84972E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84972F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497300
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849730C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497318
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497324
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497330
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849733C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497348
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497354
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497360
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849736C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497378
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497384
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497390
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849739C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84973A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84973B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84973C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84973CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84973D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84973E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84973F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84973FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497408
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497414
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497420
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849742C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497438
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84972D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84972DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84972E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84972F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849730C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849733C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849736C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849739C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84973A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84973B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84973C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84973CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84973D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84973E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84973F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84973FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849742C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497444
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 127, 154, 235 @ 8497450
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849745C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497468
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497474
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497480
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849748C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497498
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84974A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84974B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849748C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84974A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84974B0
 	voice_keysplit voicegroup005, KeySplitTable3 @ 84974BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84974C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84974C8
 	voice_keysplit voicegroup006, KeySplitTable4 @ 84974D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84974E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84974E0
 	voice_keysplit voicegroup007, KeySplitTable5 @ 84974EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84974F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497504
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497510
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849751C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497528
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497534
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497540
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849754C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497558
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497564
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497570
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849757C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497588
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497594
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84975A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84975AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84975B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84975C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84975D0
-	voice_square_1_alt 0, 1, 0, 0, 10, 0 @ 84975DC
-	voice_square_2_alt 1, 0, 0, 10, 0 @ 84975E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84975F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497600
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849760C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497618
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497624
-	voice_programmable_wave_alt gProgrammableWaveData_84A321C, 0, 0, 12, 0 @ 8497630
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849763C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497648
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497654
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497660
-	voice_programmable_wave_alt gProgrammableWaveData_84A323C, 0, 0, 12, 0 @ 849766C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84974F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849751C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849754C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849757C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84975A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84975AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84975B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84975C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84975D0
+	voice_square_1_alt 60, 0, 0, 1, 0, 0, 10, 0 @ 84975DC
+	voice_square_2_alt 60, 0, 1, 0, 0, 10, 0 @ 84975E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84975F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849760C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497624
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A321C, 0, 0, 12, 0 @ 8497630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849763C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497660
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A323C, 0, 0, 12, 0 @ 849766C
 
+	.align 2
 voicegroup155:: @ 8497678
 	voice_keysplit_all voicegroup002 @ 8497678
 	voice_keysplit voicegroup003, KeySplitTable1 @ 8497684
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497690
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849769C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849769C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165 @ 84976A8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 188, 103, 165 @ 84976B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84976C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84976CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84976D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84976E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84976F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84976FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497708
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84976C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84976CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84976D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84976E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84976F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84976FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497714
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 8497720
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849772C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849772C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497738
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 0, 255, 127 @ 8497744
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497750
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849775C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497768
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497774
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497780
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849778C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849775C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849778C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 249, 25, 127 @ 8497798
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 165, 128, 204 @ 84977A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84977B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84977BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84977C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84977B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84977BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84977C8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127 @ 84977D4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 165, 154, 165 @ 84977E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84977EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84977F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497804
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497810
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849781C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497828
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497834
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497840
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849784C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497858
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497864
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497870
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849787C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497888
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497894
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84978A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84977EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84977F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849781C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849784C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849787C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84978A0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 246, 0, 226 @ 84978AC
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84978B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84978C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84978D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84978DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84978E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84978F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497900
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849790C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84978C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84978D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84978DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84978E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84978F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849790C
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8497918
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497924
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497930
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849793C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849793C
 	voice_keysplit voicegroup007, KeySplitTable5 @ 8497948
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497954
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 165, 180, 165 @ 8497960
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849796C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497978
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497984
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497990
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849799C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84979A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84979B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84979C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84979CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84979D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84979E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84979F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84979FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497A08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497A14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497A20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497A2C
-	voice_square_1_alt 0, 1, 0, 2, 7, 2 @ 8497A38
-	voice_square_2_alt 3, 0, 3, 6, 2 @ 8497A44
-	voice_square_2_alt 3, 0, 2, 6, 5 @ 8497A50
-	voice_programmable_wave_alt gProgrammableWaveData_84A324C, 0, 3, 6, 5 @ 8497A5C
-	voice_square_2_alt 0, 0, 2, 6, 5 @ 8497A68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497A74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497A80
-	voice_programmable_wave_alt gProgrammableWaveData_84A320C, 0, 7, 15, 1 @ 8497A8C
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 8497A98
-	voice_programmable_wave_alt gProgrammableWaveData_84A327C, 0, 1, 9, 2 @ 8497AA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497AB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497ABC
-	voice_square_2_alt 2, 0, 2, 6, 3 @ 8497AC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497AD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497AE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497AEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497AF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497B94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497BA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497BAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497BB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497BC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497BD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497BDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497BE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497BF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497C00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849796C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849799C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84979A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84979B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84979C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84979CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84979D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84979E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84979F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84979FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497A2C
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 7, 2 @ 8497A38
+	voice_square_2_alt 60, 0, 3, 0, 3, 6, 2 @ 8497A44
+	voice_square_2_alt 60, 0, 3, 0, 2, 6, 5 @ 8497A50
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A324C, 0, 3, 6, 5 @ 8497A5C
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5 @ 8497A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497A80
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A320C, 0, 7, 15, 1 @ 8497A8C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 8497A98
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A327C, 0, 1, 9, 2 @ 8497AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497ABC
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 3 @ 8497AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497BDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497BE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497C0C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165 @ 8497C18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497C24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497C30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497C3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497C48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497C54
-	voice_noise_alt 0, 0, 2, 6, 2 @ 8497C60
-	voice_noise_alt 0, 0, 1, 6, 0 @ 8497C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497C54
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 2 @ 8497C60
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0 @ 8497C6C
 
+	.align 2
 voicegroup156:: @ 8497C78
 	voice_keysplit_all voicegroup002 @ 8497C78
 	voice_keysplit voicegroup003, KeySplitTable1 @ 8497C84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497C90
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8497C9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497CA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497C90
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8497C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497CA8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165 @ 8497CB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497CC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497CCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497CD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497CE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497CF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497CFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497D08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497D14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497D20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497D2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497D38
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 0, 255, 127 @ 8497D44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497D50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497D5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497D68
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 255, 0, 255, 165 @ 8497D74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497D80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497D8C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 165, 128, 204 @ 8497D98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497DA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497DB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497DBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497DC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497DC8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127 @ 8497DD4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127 @ 8497DE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497DEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497DF8
-	voice_square_2_alt 3, 0, 4, 4, 4 @ 8497E04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497E10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497DF8
+	voice_square_2_alt 60, 0, 3, 0, 4, 4, 4 @ 8497E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497E1C
 	voice_directsound 60, 0, DirectSoundWaveData_unused_sc88pro_unison_slap, 255, 165, 180, 216 @ 8497E28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497E34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497E40
-	voice_square_2_alt 1, 0, 1, 7, 5 @ 8497E4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497E58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497E64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497E70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497E7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497E88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497E94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497EA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497E40
+	voice_square_2_alt 60, 0, 1, 0, 1, 7, 5 @ 8497E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497EAC
 	voice_keysplit voicegroup004, KeySplitTable2 @ 8497EB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497EC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497ED0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497EDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497EE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497EF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497F00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497F0C
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8497F18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497F24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497F30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497F3C
 	voice_keysplit voicegroup007, KeySplitTable5 @ 8497F48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497F54
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 127 @ 8497F60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497F6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497F78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497F84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497F90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497F9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497FA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497FB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497FC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497FCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497FD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497FE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497FF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8497FFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498008
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498014
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498020
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849802C
-	voice_square_2_alt 2, 0, 2, 3, 1 @ 8498038
-	voice_square_1_alt 0, 0, 0, 2, 7, 5 @ 8498044
-	voice_square_1_alt 0, 3, 0, 2, 6, 5 @ 8498050
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849805C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498068
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498074
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498080
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849808C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498098
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84980A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84980B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84980BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84980C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84980D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84980E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84980EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84980F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498104
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498110
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849811C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498128
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498134
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498140
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849814C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498158
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498164
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498170
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849817C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498188
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498194
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84981A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84981AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84981B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84981C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84981D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84981DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84981E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84981F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498200
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849820C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497FB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497FC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8497FFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849802C
+	voice_square_2_alt 60, 0, 2, 0, 2, 3, 1 @ 8498038
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 7, 5 @ 8498044
+	voice_square_1_alt 60, 0, 0, 3, 0, 2, 6, 5 @ 8498050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849805C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849808C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84980A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84980B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84980BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84980C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84980D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84980E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84980EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84980F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849811C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849814C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849817C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84981A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84981AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84981B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84981C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84981D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84981DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84981E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84981F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849820C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165 @ 8498218
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498224
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498230
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849823C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498248
-	voice_noise_alt 0, 0, 0, 15, 0 @ 8498254
-	voice_noise_alt 0, 0, 2, 6, 0 @ 8498260
-	voice_noise_alt 0, 0, 1, 6, 0 @ 849826C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849823C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498248
+	voice_noise_alt 60, 0, 0, 0, 0, 15, 0 @ 8498254
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 8498260
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0 @ 849826C
 
+	.align 2
 voicegroup157:: @ 8498278
 	voice_keysplit_all voicegroup002 @ 8498278
 	voice_keysplit voicegroup003, KeySplitTable1 @ 8498284
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498290
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849829C
-	voice_square_2_alt 3, 0, 2, 6, 5 @ 84982A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84982B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84982C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84982CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84982D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84982E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84982F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84982FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498308
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498314
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498320
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849832C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849829C
+	voice_square_2_alt 60, 0, 3, 0, 2, 6, 5 @ 84982A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84982B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84982C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84982CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84982D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84982E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84982F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84982FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849832C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498338
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 128, 146, 190, 115 @ 8498344
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498350
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849835C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849835C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498368
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 255, 0, 255, 165 @ 8498374
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498380
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849838C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849838C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 165, 128, 204 @ 8498398
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84983A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84983B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84983BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84983C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84983A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84983B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84983BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84983C8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127 @ 84983D4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127 @ 84983E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84983EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84983F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84983EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84983F8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fingered_bass, 255, 253, 0, 149 @ 8498404
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498410
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849841C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849841C
 	voice_directsound 60, 0, DirectSoundWaveData_unused_sc88pro_unison_slap, 255, 165, 180, 216 @ 8498428
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498434
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 255, 252, 0, 115 @ 8498440
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849844C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498458
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498464
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498470
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849847C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498488
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498494
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84984A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84984AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849844C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849847C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84984A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84984AC
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84984B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84984C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84984D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84984DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84984E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84984F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498500
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849850C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84984C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84984D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84984DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84984E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84984F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849850C
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8498518
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498524
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498530
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849853C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849853C
 	voice_keysplit voicegroup007, KeySplitTable5 @ 8498548
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498554
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 127 @ 8498560
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849856C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498578
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498584
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498590
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849859C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84985A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84985B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84985C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84985CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84985D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84985E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84985F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84985FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498608
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498614
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498620
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849862C
-	voice_square_1_alt 0, 1, 0, 2, 7, 2 @ 8498638
-	voice_square_2_alt 3, 0, 3, 3, 0 @ 8498644
-	voice_programmable_wave_alt gProgrammableWaveData_84A324C, 0, 3, 6, 5 @ 8498650
-	voice_square_1_alt 0, 0, 0, 2, 7, 2 @ 849865C
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 8498668
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498674
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498680
-	voice_programmable_wave_alt gProgrammableWaveData_84A323C, 0, 7, 15, 0 @ 849868C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498698
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84986A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84986B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84986BC
-	voice_square_2_alt 2, 0, 2, 6, 3 @ 84986C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84986D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84986E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84986EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84986F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498704
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498710
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849871C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498728
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498734
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498740
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849874C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498758
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498764
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498770
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849877C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498788
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498794
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84987A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84987AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84987B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84987C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84987D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84987DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84987E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84987F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498800
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849880C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498818
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498824
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498830
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849883C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498848
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498854
-	voice_noise_alt 0, 0, 2, 6, 0 @ 8498860
-	voice_noise_alt 0, 0, 1, 6, 1 @ 849886C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849856C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849859C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84985A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84985B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84985C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84985CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84985D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84985E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84985F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84985FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849862C
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 7, 2 @ 8498638
+	voice_square_2_alt 60, 0, 3, 0, 3, 3, 0 @ 8498644
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A324C, 0, 3, 6, 5 @ 8498650
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 7, 2 @ 849865C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 8498668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498680
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A323C, 0, 7, 15, 0 @ 849868C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84986A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84986B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84986BC
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 3 @ 84986C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84986D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84986E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84986EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84986F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849871C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849874C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849877C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84987A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84987AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84987B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84987C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84987D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84987DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84987E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84987F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849880C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849883C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498854
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 8498860
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1 @ 849886C
 
+	.align 2
 voicegroup158:: @ 8498878
 	voice_keysplit_all voicegroup002 @ 8498878
 	voice_keysplit voicegroup003, KeySplitTable1 @ 8498884
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498890
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849889C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849889C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165 @ 84988A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84988B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84988C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84988CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84988D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84988E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84988B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84988C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84988CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84988D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84988E4
 	voice_directsound 60, 0, DirectSoundWaveData_ethnic_flavours_atarigane, 255, 0, 255, 0 @ 84988F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84988FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498908
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84988FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498914
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 8498920
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849892C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849892C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498938
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 128, 146, 108, 137 @ 8498944
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498950
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849895C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498968
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498974
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498980
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849898C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849895C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849898C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 204, 103, 226 @ 8498998
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84989A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84989B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84989BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84989C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84989A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84989B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84989BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84989C8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127 @ 84989D4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127 @ 84989E0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165 @ 84989EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84989F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498A04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84989F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498A10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 253, 0, 188 @ 8498A1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498A28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498A34
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 255, 252, 0, 115 @ 8498A40
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 255, 0, 255, 127 @ 8498A4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498A58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498A64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498A70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498A7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498A88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498A94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498A58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498A64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498AA0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 0, 193, 153 @ 8498AAC
 	voice_keysplit voicegroup004, KeySplitTable2 @ 8498AB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498AC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498AD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498ADC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498AE8
 	voice_directsound 60, 0, DirectSoundWaveData_classical_choir_voice_ahhs, 255, 0, 255, 0 @ 8498AF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498B00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498B0C
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8498B18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498B24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498B30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498B3C
 	voice_keysplit voicegroup007, KeySplitTable5 @ 8498B48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498B54
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 236, 188 @ 8498B60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498B6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498B78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498B84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498B90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498B9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498BA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498BB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498BC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498BCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498BD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498BE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498BF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498BFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498C08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498C14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498BF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498C08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498C14
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127 @ 8498C20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498C2C
-	voice_square_1_alt 0, 1, 0, 1, 9, 0 @ 8498C38
-	voice_square_2_alt 3, 0, 1, 10, 1 @ 8498C44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498C50
-	voice_square_2_alt 2, 1, 0, 9, 1 @ 8498C5C
-	voice_programmable_wave_alt gProgrammableWaveData_84A323C, 0, 7, 15, 0 @ 8498C68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498C74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498C80
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8498C8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498C98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498CA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498CB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498CBC
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 0, 15, 0 @ 8498CC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498CD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498CE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498CEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498CF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498D94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498DA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498DAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498DB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498DC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498DD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498DDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498DE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498DF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E54
-	voice_noise_alt 0, 0, 2, 6, 0 @ 8498E60
-	voice_noise_alt 0, 0, 1, 8, 1 @ 8498E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498C2C
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 9, 0 @ 8498C38
+	voice_square_2_alt 60, 0, 3, 0, 1, 10, 1 @ 8498C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498C50
+	voice_square_2_alt 60, 0, 2, 1, 0, 9, 1 @ 8498C5C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A323C, 0, 7, 15, 0 @ 8498C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498C80
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8498C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498CBC
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 0, 15, 0 @ 8498CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498CD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E54
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 8498E60
+	voice_noise_alt 60, 0, 0, 0, 1, 8, 1 @ 8498E6C
 
+	.align 2
 voicegroup159:: @ 8498E78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498E9C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 64, 249, 0, 188 @ 8498EA8
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 51, 249, 0, 165 @ 8498EB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498EC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498ECC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498ED8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498EE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498EF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498EFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498ED8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498F8C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 85, 249, 25, 127 @ 8498F98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498FA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498FB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498FBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498FC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498FD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498FE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498FEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8498FF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499004
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499010
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849901C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499028
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499034
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499040
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849904C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499058
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499064
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499070
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849907C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499088
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499094
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84990A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84990AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498FBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498FC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498FD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8498FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849901C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849904C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849907C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84990A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84990AC
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84990B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84990C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84990D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84990DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84990E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84990F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499100
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849910C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499118
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499124
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499130
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849913C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499148
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499154
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499160
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849916C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499178
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499184
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499190
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849919C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84991A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84991B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84991C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84991CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84991D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84991E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84991F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84991FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499208
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499214
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499220
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849922C
-	voice_square_1_alt 0, 2, 0, 7, 0, 6 @ 8499238
-	voice_square_2_alt 1, 1, 5, 1, 6 @ 8499244
-	voice_programmable_wave_alt gProgrammableWaveData_84A31FC, 1, 7, 0, 6 @ 8499250
-	voice_square_1_alt 0, 0, 1, 4, 3, 6 @ 849925C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499268
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499274
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499280
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849928C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499298
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84992A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84992B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84992BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84992C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84992D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84992E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84992EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84992F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499304
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499310
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849931C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499328
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499334
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499340
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849934C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499358
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499364
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499370
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849937C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499388
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499394
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84993A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84993AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84993B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84993C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84993D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84993DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84993E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84993F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499400
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849940C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499418
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499424
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499430
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849943C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499448
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499454
-	voice_noise_alt 0, 0, 2, 4, 0 @ 8499460
-	voice_noise_alt 0, 0, 1, 0, 0 @ 849946C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84990C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84990D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84990DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84990E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84990F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849910C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849913C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849916C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849919C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84991A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84991B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84991C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84991CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84991D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84991E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84991F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84991FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849922C
+	voice_square_1_alt 60, 0, 0, 2, 0, 7, 0, 6 @ 8499238
+	voice_square_2_alt 60, 0, 1, 1, 5, 1, 6 @ 8499244
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31FC, 1, 7, 0, 6 @ 8499250
+	voice_square_1_alt 60, 0, 0, 0, 1, 4, 3, 6 @ 849925C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849928C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84992A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84992B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84992BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84992C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84992D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84992E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84992EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84992F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849931C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849934C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849937C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84993A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84993AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84993B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84993C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84993D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84993DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84993E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84993F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849940C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849943C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499454
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0 @ 8499460
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0 @ 849946C
 
+	.align 2
 voicegroup160:: @ 8499478
 	voice_keysplit_all voicegroup001 @ 8499478
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499484
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499490
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849949C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84994A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84994B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84994C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84994CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84994D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84994E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84994F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84994FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499508
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849949C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84994A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84994B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84994C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84994CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84994D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84994E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84994F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84994FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499514
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 8499520
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849952C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499538
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499544
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499550
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849955C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499568
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499574
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499580
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849958C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849952C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849955C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849958C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 249, 25, 127 @ 8499598
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84995A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84995B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84995BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84995C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84995D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84995E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84995EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84995F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499604
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84995A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84995B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84995BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84995C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84995D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84995E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84995EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84995F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499610
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 253, 0, 188 @ 849961C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499628
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499634
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499640
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849964C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499658
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499664
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499670
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849967C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499688
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499694
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84996A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84996AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849964C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849967C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84996A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84996AC
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84996B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84996C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84996D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84996DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84996E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84996F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499700
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849970C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499718
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499724
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499730
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849973C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499748
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499754
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499760
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849976C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499778
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499784
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499790
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849979C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84997A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84997B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84997C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84997CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84997D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84997E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84997F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84997FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499808
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499814
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499820
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849982C
-	voice_square_1_alt 0, 1, 0, 2, 3, 1 @ 8499838
-	voice_square_2_alt 1, 0, 2, 4, 2 @ 8499844
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499850
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849985C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499868
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499874
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499880
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849988C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84996C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84996D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84996DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84996E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84996F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849970C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849973C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849976C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849979C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84997A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84997B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84997C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84997CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84997D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84997E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84997F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84997FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849982C
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 3, 1 @ 8499838
+	voice_square_2_alt 60, 0, 1, 0, 2, 4, 2 @ 8499844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849985C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499880
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849988C
 
+	.align 2
 voicegroup161:: @ 8499898
 	voice_keysplit_all voicegroup002 @ 8499898
 	voice_keysplit voicegroup003, KeySplitTable1 @ 84998A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84998B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84998BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84998C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84998D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84998E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84998EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84998F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499904
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499910
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849991C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499928
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84998B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84998BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84998C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84998D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84998E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84998EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84998F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849991C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499934
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 8499940
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849994C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849994C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499958
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 0, 255, 127 @ 8499964
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499970
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849997C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849997C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499988
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 255, 0, 255, 165 @ 8499994
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84999A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84999AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84999B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84999C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84999D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84999DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84999E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84999F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499A9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499AA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499AB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499AC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84999A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84999AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84999B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84999C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84999D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84999DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84999E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84999F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499ACC
 	voice_keysplit voicegroup004, KeySplitTable2 @ 8499AD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499AE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499AF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499AFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499B08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499B14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499B20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499B2C
 	voice_keysplit voicegroup005, KeySplitTable3 @ 8499B38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499B44
 	voice_keysplit voicegroup006, KeySplitTable4 @ 8499B50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499B5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499B68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499B74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499B80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499B8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499B98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499BA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499BB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499BBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499BC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499BD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499BE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499BEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499B74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499BBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499BC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499BD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499BF8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 0, 255, 165 @ 8499C04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499C10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499C1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499C28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499C34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499C40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499C4C
-	voice_square_1_alt 0, 2, 0, 2, 6, 4 @ 8499C58
-	voice_square_2_alt 2, 0, 2, 6, 2 @ 8499C64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499C70
-	voice_square_2_alt 1, 0, 2, 6, 2 @ 8499C7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499C88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499C94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499CA0
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8499CAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499CB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499CC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499CD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499CDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499CE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499CF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499D9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499DA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499DB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499DC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499DCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499DD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499DE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499DF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499DFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499E08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499E14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499E20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499E2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499E38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499E44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499E50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499E5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499E68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499E74
-	voice_noise_alt 0, 0, 2, 4, 0 @ 8499E80
-	voice_noise_alt 0, 0, 1, 0, 0 @ 8499E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499C4C
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 6, 4 @ 8499C58
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 2 @ 8499C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499C70
+	voice_square_2_alt 60, 0, 1, 0, 2, 6, 2 @ 8499C7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499CA0
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 8499CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499DE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499DF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499DFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499E08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499E20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499E68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499E74
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0 @ 8499E80
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0 @ 8499E8C
 
+	.align 2
 voicegroup162:: @ 8499E98
 	voice_keysplit_all voicegroup002 @ 8499E98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499EA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499EB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499EA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499EBC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 64, 188, 108, 244 @ 8499EC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499ED4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499EE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499EEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499EF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499F04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499F10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499F1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499F28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499F34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499EE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499EEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499EF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499F04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499F1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499F28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499F34
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 8499F40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499F4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499F58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499F4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499F58
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 64, 195, 92, 235 @ 8499F64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499F70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499F7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499F88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499F94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499FA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499FAC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 249, 25, 127 @ 8499FB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499FC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499FD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499FDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499FE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 8499FF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A000
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A00C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 8499FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A00C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A018
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fingered_bass, 64, 204, 113, 235 @ 849A024
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A030
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A03C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A048
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A054
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A060
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A06C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A078
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A084
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A090
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A09C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A0A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A0B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A0C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A0CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A03C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A06C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A09C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A0A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A0B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A0C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A0CC
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849A0D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A0E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A0F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A0FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A108
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A114
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A120
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A12C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A138
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A144
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A150
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A15C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A168
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A174
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A180
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A18C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A198
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A1A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A1B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A1BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A1C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A1D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A1E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A1EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A1F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A204
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A210
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A21C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A228
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A234
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A240
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A24C
-	voice_square_1_alt 0, 1, 0, 0, 6, 0 @ 849A258
-	voice_square_2_alt 1, 0, 0, 6, 0 @ 849A264
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A270
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A27C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A288
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A294
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A2A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A2AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A2B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A2C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A2D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A2DC
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849A2E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A0E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A0F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A0FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A12C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A15C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A18C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A1A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A1B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A1BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A1C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A1D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A1E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A1EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A1F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A21C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A24C
+	voice_square_1_alt 60, 0, 0, 1, 0, 0, 6, 0 @ 849A258
+	voice_square_2_alt 60, 0, 1, 0, 0, 6, 0 @ 849A264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A27C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A2A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A2AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A2B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A2C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A2D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A2DC
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849A2E8
 
+	.align 2
 voicegroup163:: @ 849A2F4
 	voice_keysplit_all voicegroup002 @ 849A2F4
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849A300
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A30C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A30C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A318
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226 @ 849A324
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 204, 77, 246 @ 849A330
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A33C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A348
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A354
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A360
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A36C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A378
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A384
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A390
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A39C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A3A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A3B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A33C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A36C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A39C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A3A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A3B4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 76, 133, 137 @ 849A3C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A3CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A3D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A3E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A3CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A3D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A3E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 64, 188, 108, 165 @ 849A3F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A3FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A3FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A408
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 249, 25, 127 @ 849A414
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A420
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A42C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A438
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A444
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A450
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A45C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A468
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A474
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A480
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A48C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A498
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A4A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A4B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A4BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A4C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A4D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A4E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A4EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A4F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A504
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A42C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A45C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A48C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A498
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A4A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A4B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A4BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A4C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A4D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A4E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A4EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A4F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A510
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 246, 0, 235 @ 849A51C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A528
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849A534
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A540
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A54C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A558
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A564
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A570
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A57C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A54C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A57C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A588
 	voice_keysplit voicegroup005, KeySplitTable3 @ 849A594
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A5A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A5A0
 	voice_directsound 60, 0, DirectSoundWaveData_wave_77, 255, 0, 206, 204 @ 849A5AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A5B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A5C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A5D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A5DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A5E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A5F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A600
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A60C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A618
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A624
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A630
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A63C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A648
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A5B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A5C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A5D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A5DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A5E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A5F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A60C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A63C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A654
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 849A660
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A66C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A678
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A684
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A690
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A69C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A6A8
-	voice_square_1_alt 0, 0, 0, 1, 5, 2 @ 849A6B4
-	voice_square_2_alt 3, 0, 3, 4, 2 @ 849A6C0
-	voice_square_2_alt 0, 0, 2, 6, 5 @ 849A6CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A6D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A6E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A6F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A6FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A708
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A714
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A720
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A72C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A738
-	voice_programmable_wave_alt gProgrammableWaveData_84A326C, 0, 0, 12, 0 @ 849A744
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A750
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A75C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A768
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A774
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A780
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A78C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A798
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A7A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A7B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A7BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A7C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A7D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A7E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A7EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A7F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A804
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A810
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A81C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A828
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A834
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A840
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A84C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A858
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A864
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A870
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A87C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A888
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A894
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A8A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A8AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A8B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A8C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A8D0
-	voice_noise_alt 0, 0, 2, 6, 0 @ 849A8DC
-	voice_noise_alt 0, 0, 1, 6, 0 @ 849A8E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A66C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A69C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A6A8
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 5, 2 @ 849A6B4
+	voice_square_2_alt 60, 0, 3, 0, 3, 4, 2 @ 849A6C0
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5 @ 849A6CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A6D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A6E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A6F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A6FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A72C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A738
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A326C, 0, 0, 12, 0 @ 849A744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A75C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A78C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A7A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A7B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A7BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A7C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A7D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A7E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A7EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A7F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A81C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A84C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A87C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A8A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A8AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A8B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A8C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A8D0
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 849A8DC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0 @ 849A8E8
 
+	.align 2
 voicegroup164:: @ 849A8F4
 	voice_keysplit_all voicegroup002 @ 849A8F4
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849A900
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A90C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A90C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A918
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 128, 180, 108, 209 @ 849A924
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 85, 204, 77, 246 @ 849A930
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A93C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A948
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A954
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A960
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A96C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A978
-	voice_square_1_alt 0, 2, 0, 0, 10, 6 @ 849A984
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A990
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A99C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A9A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A9B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A93C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A96C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A978
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 10, 6 @ 849A984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A99C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A9A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A9B4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 76, 133, 137 @ 849A9C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A9CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A9D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A9E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A9CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A9D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A9E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 64, 188, 108, 165 @ 849A9F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849A9FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849A9FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA08
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 249, 25, 127 @ 849AA14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AA98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AAA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AAB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AABC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AAC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AAD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AAE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AAEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AAF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AB04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AB10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AA98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AAA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AAB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AAC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AAD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AAE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AAEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AAF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AB04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AB10
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 246, 0, 235 @ 849AB1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AB28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AB28
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849AB34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AB40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AB4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AB58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AB64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AB70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AB7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AB88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AB94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ABA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ABAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ABB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ABC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ABD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ABDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ABE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ABF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AB40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AB4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AB58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AB64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AB70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AB7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AB88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AB94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ABA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ABAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ABB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ABC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ABD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ABDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ABE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ABF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC54
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 849AC60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AC9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ACA8
-	voice_square_2_alt 2, 0, 2, 6, 2 @ 849ACB4
-	voice_square_1_alt 0, 2, 0, 1, 7, 4 @ 849ACC0
-	voice_programmable_wave_alt gProgrammableWaveData_84A328C, 0, 0, 12, 0 @ 849ACCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ACD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ACE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ACF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ACFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD38
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 0, 12, 0 @ 849AD44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AD98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ADA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ADB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ADBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ADC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ADD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ADE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ADEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ADF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AE94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AEA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AEAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AEB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AEC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AED0
-	voice_noise_alt 0, 0, 2, 6, 0 @ 849AEDC
-	voice_noise_alt 0, 0, 1, 6, 0 @ 849AEE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AC9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ACA8
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 2 @ 849ACB4
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 4 @ 849ACC0
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A328C, 0, 0, 12, 0 @ 849ACCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ACD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ACE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ACF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ACFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD38
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 0, 12, 0 @ 849AD44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AD98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ADA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ADB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ADBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ADC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ADD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ADE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ADEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ADF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AE94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AEA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AEAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AEB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AEC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AED0
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 849AEDC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0 @ 849AEE8
 
+	.align 2
 voicegroup165:: @ 849AEF4
 	voice_keysplit_all voicegroup002 @ 849AEF4
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849AF00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AF0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AF18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AF24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AF30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AF3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AF48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AF54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AF0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AF18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AF24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AF30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AF3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AF48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AF54
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_glockenspiel, 255, 165, 51, 242 @ 849AF60
 	voice_directsound 60, 0, DirectSoundWaveData_ethnic_flavours_atarigane, 255, 0, 255, 0 @ 849AF6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AF78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AF84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AF78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AF84
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_xylophone, 255, 235, 0, 204 @ 849AF90
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 849AF9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AFA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AFB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AFA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AFB4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 37, 165, 103, 127 @ 849AFC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AFCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AFD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AFE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AFF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849AFFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AFCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AFD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AFE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AFF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849AFFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B008
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 204, 92, 226 @ 849B014
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B020
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B02C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B038
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B044
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B050
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B05C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B068
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B074
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B080
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B08C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B098
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B0A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B0B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B0BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B0C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B0D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B0E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B0EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B0F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B104
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B02C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B05C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B08C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B0A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B0B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B0BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B0C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B0D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B0E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B0EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B0F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B110
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 242, 51, 226 @ 849B11C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B128
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849B134
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B140
-	voice_square_1_alt 0, 2, 0, 2, 10, 1 @ 849B14C
-	voice_square_2_alt 2, 0, 2, 6, 6 @ 849B158
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B164
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B170
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B17C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B188
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B194
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B1A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B140
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 10, 1 @ 849B14C
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 6 @ 849B158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B164
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B17C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B1A0
 	voice_keysplit voicegroup006, KeySplitTable4 @ 849B1AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B1B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B1B8
 	voice_keysplit voicegroup007, KeySplitTable5 @ 849B1C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B1D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B1DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B1E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B1F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B200
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B20C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B218
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B224
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B230
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B23C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B248
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B1D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B1DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B1E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B1F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B20C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B224
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B23C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B254
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 0, 255, 165 @ 849B260
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B26C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B26C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_enhanced_delay_shaku, 255, 191, 97, 165 @ 849B278
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B284
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B284
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B290
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127 @ 849B29C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B2A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B2B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B2C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B2CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B2D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B2E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B2F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B2FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B308
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B314
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B320
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B32C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B338
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849B344
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B350
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B35C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B368
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B374
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B380
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B38C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B398
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B3A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B3B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B3BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B3C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B3D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B3E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B3EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B3F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B404
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B410
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B41C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B428
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B434
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B440
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B44C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B458
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B464
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B470
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B47C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B488
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B494
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B4A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B4AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B4B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B4C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B4D0
-	voice_noise_alt 0, 0, 1, 9, 0 @ 849B4DC
-	voice_noise_alt 0, 0, 1, 6, 1 @ 849B4E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B2A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B2B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B2C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B2CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B2D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B2E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B2F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B2FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B32C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B338
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849B344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B35C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B38C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B3A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B3B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B3BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B3C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B3D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B3E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B3EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B3F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B410
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B41C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B44C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B47C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B4A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B4AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B4B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B4C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B4D0
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 0 @ 849B4DC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1 @ 849B4E8
 
+	.align 2
 voicegroup166:: @ 849B4F4
 	voice_keysplit_all voicegroup002 @ 849B4F4
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849B500
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B50C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B518
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B524
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B530
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B53C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B548
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B554
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B50C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B53C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B560
 	voice_directsound 60, 0, DirectSoundWaveData_ethnic_flavours_atarigane, 255, 0, 255, 0 @ 849B56C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B578
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B584
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B590
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 849B59C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B5A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B5B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B5A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B5B4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 128, 146, 108, 137 @ 849B5C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B5CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B5D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B5E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B5F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B5FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B5CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B5D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B5E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B5F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B5FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B608
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 204, 103, 226 @ 849B614
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B620
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B62C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B638
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B62C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B644
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 255, 0, 255, 127 @ 849B650
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 255, 0, 255, 127 @ 849B65C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165 @ 849B668
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B674
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B680
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B68C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B68C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 253, 0, 188 @ 849B698
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B6A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B6B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B6A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B6B0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 255, 252, 0, 115 @ 849B6BC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_square_wave, 255, 0, 255, 127 @ 849B6C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B6D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B6E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B6EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B6F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B704
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B710
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B71C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B6D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B6E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B6EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B6F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B71C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 0, 193, 153 @ 849B728
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849B734
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B740
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B74C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B758
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B764
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B770
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B77C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B74C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B77C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B788
 	voice_keysplit voicegroup005, KeySplitTable3 @ 849B794
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B7A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B7AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B7B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B7A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B7AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B7B8
 	voice_keysplit voicegroup007, KeySplitTable5 @ 849B7C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B7D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B7D0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 236, 188 @ 849B7DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B7E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B7F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B800
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B80C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B818
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B824
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B830
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B83C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B848
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B854
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B860
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B86C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B878
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B884
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B7E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B7F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B80C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B83C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B86C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B890
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127 @ 849B89C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B8A8
-	voice_square_1_alt 0, 3, 0, 1, 9, 0 @ 849B8B4
-	voice_square_2_alt 3, 0, 2, 9, 1 @ 849B8C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B8CC
-	voice_square_2_alt 2, 1, 0, 9, 1 @ 849B8D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B8E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B8F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B8FC
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849B908
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B914
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B920
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B92C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B938
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 0, 15, 0 @ 849B944
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B950
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B95C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B968
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B974
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B980
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B98C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B998
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B9A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B9B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B9BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B9C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B9D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B9E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B9EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849B9F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BA94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BAA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BAAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BAB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BAC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BAD0
-	voice_noise_alt 0, 0, 2, 6, 0 @ 849BADC
-	voice_noise_alt 0, 0, 1, 8, 1 @ 849BAE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B8A8
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 9, 0 @ 849B8B4
+	voice_square_2_alt 60, 0, 3, 0, 2, 9, 1 @ 849B8C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B8CC
+	voice_square_2_alt 60, 0, 2, 1, 0, 9, 1 @ 849B8D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B8E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B8F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B8FC
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849B908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B92C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B938
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 0, 15, 0 @ 849B944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B95C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B98C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B9A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B9B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B9BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B9C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B9D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B9E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B9EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849B9F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BA94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BAA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BAAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BAB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BAC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BAD0
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 849BADC
+	voice_noise_alt 60, 0, 0, 0, 1, 8, 1 @ 849BAE8
 
+	.align 2
 voicegroup167:: @ 849BAF4
 	voice_keysplit_all voicegroup002 @ 849BAF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BB9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BBA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BBB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BB9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BBA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BBB4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 76, 133, 137 @ 849BBC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BBCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BBD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BBE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BBCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BBD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BBE4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 64, 188, 108, 165 @ 849BBF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BBFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BBFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC08
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 249, 25, 127 @ 849BC14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BC98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BCA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BCB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BCBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BCC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BCD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BCE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BCEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BCF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BD88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BC98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BCA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BCB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BCBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BCC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BCD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BCE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BCEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BCF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BD88
 	voice_keysplit voicegroup005, KeySplitTable3 @ 849BD94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BDA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BDAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BDB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BDC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BDD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BDDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BDE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BDF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BE9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BEA8
-	voice_square_1_alt 0, 0, 0, 1, 10, 4 @ 849BEB4
-	voice_square_2_alt 3, 0, 2, 8, 3 @ 849BEC0
-	voice_square_2_alt 2, 0, 2, 6, 5 @ 849BECC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BED8
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 0, 6, 0 @ 849BEE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BEF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BEFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BF98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BFA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BFB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BFBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BFC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BFD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BFE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BFEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849BFF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C004
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C010
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C01C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C028
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C034
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C040
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C04C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C058
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C064
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C070
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C07C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C088
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C094
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C0A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C0AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C0B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C0C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C0D0
-	voice_noise_alt 0, 0, 2, 6, 0 @ 849C0DC
-	voice_noise_alt 0, 0, 1, 6, 0 @ 849C0E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BDA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BDAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BDB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BDC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BDD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BDDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BDE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BDF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BE9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BEA8
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 10, 4 @ 849BEB4
+	voice_square_2_alt 60, 0, 3, 0, 2, 8, 3 @ 849BEC0
+	voice_square_2_alt 60, 0, 2, 0, 2, 6, 5 @ 849BECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BED8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 0, 6, 0 @ 849BEE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BEF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BEFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BF98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BFA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BFB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BFBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BFC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BFD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BFE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BFEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849BFF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C01C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C04C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C07C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C0A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C0AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C0B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C0C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C0D0
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 849C0DC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0 @ 849C0E8
 
+	.align 2
 voicegroup168:: @ 849C0F4
 	voice_keysplit_all voicegroup002 @ 849C0F4
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849C100
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C10C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C10C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C118
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226 @ 849C124
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 204, 77, 246 @ 849C130
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C13C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C148
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C154
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C160
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C16C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C178
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C184
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C190
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C19C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C1A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C1B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C13C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C16C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C19C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C1A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C1B4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 76, 133, 137 @ 849C1C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C1CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C1D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C1E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C1CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C1D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C1E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 64, 188, 108, 165 @ 849C1F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C1FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C208
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C1FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C208
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 249, 25, 127 @ 849C214
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C220
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C22C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C238
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C244
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C250
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C25C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C268
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C274
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C280
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C28C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C298
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C2A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C2B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C2BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C2C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C2D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C2E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C2EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C2F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C22C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C25C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C28C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C2A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C2B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C2BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C2C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C2D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C2E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C2EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C2F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C304
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_pizzicato_strings, 255, 216, 0, 165 @ 849C310
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 246, 0, 235 @ 849C31C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C328
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849C334
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C340
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C34C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C358
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C364
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C370
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C37C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C388
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C394
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C3A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C3AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C3B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C34C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C37C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C3A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C3AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C3B8
 	voice_keysplit voicegroup007, KeySplitTable5 @ 849C3C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C3D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C3DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C3E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C3F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C400
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C40C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C418
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C424
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C430
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C43C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C448
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C3D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C3DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C3E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C3F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C40C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C43C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C454
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 849C460
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C46C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C478
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C484
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C490
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C49C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C4A8
-	voice_square_1_alt 0, 1, 0, 1, 4, 2 @ 849C4B4
-	voice_square_2_alt 3, 0, 2, 6, 4 @ 849C4C0
-	voice_square_2_alt 0, 0, 2, 6, 5 @ 849C4CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C4D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C4E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C4F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C4FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C508
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C514
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C520
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C52C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C538
-	voice_programmable_wave_alt gProgrammableWaveData_84A326C, 0, 0, 12, 0 @ 849C544
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C550
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C55C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C568
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C574
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C580
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C58C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C598
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C5A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C5B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C5BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C5C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C5D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C5E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C5EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C5F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C604
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C610
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C61C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C628
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C634
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C640
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C64C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C658
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C664
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C670
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C67C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C688
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C694
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C6A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C6AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C6B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C6C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C6D0
-	voice_noise_alt 0, 0, 2, 6, 0 @ 849C6DC
-	voice_noise_alt 0, 0, 1, 6, 0 @ 849C6E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C46C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C49C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C4A8
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 4, 2 @ 849C4B4
+	voice_square_2_alt 60, 0, 3, 0, 2, 6, 4 @ 849C4C0
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5 @ 849C4CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C4D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C4E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C4F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C4FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C52C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C538
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A326C, 0, 0, 12, 0 @ 849C544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C55C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C574
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C58C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C5A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C5B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C5BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C5C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C5D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C5E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C5EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C5F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C61C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C64C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C67C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C6A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C6AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C6B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C6C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C6D0
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 849C6DC
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0 @ 849C6E8
 
+	.align 2
 voicegroup169:: @ 849C6F4
 	voice_keysplit_all voicegroup001 @ 849C6F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C700
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C70C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C718
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C724
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C730
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C73C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C748
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C754
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C760
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C76C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C778
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C784
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C790
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C79C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C7A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C7B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C70C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C73C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C76C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C79C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C7A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C7B4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 0, 255, 210 @ 849C7C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C7CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C7D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C7E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C7F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C7FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C808
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C814
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C820
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C82C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C838
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C844
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C850
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C85C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C868
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C874
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C880
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C88C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C7CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C7D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C7E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C7F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C7FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C82C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C844
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C85C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C88C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 253, 0, 188 @ 849C898
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C8A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C8B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C8BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C8C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C8D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C8E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C8EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C8F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C904
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C910
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C91C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C928
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C934
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C940
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C94C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C958
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C964
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C970
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C97C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C8A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C8B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C8BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C8C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C8D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C8E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C8EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C8F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C91C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C94C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C97C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C988
 	voice_keysplit voicegroup005, KeySplitTable3 @ 849C994
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C9A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C9A0
 	voice_keysplit voicegroup006, KeySplitTable4 @ 849C9AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C9B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C9C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C9D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C9DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C9E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849C9F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA6C
-	voice_programmable_wave_alt gProgrammableWaveData_84A31FC, 0, 7, 15, 0 @ 849CA78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CA9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CAA8
-	voice_square_1_alt 0, 2, 0, 1, 4, 1 @ 849CAB4
-	voice_square_2_alt 2, 0, 1, 4, 1 @ 849CAC0
-	voice_square_2_alt 0, 0, 1, 4, 1 @ 849CACC
-	voice_square_1_alt 0, 0, 0, 1, 4, 1 @ 849CAD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CAE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CAF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CAFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CB98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CBA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CBB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CBBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CBC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CBD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CBE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CBEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CBF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CC94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CCA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CCAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CCB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CCC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CCD0
-	voice_noise_alt 0, 0, 2, 4, 0 @ 849CCDC
-	voice_noise_alt 0, 0, 1, 0, 0 @ 849CCE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C9B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C9C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C9D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C9DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C9E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849C9F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA6C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31FC, 0, 7, 15, 0 @ 849CA78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CA9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CAA8
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 4, 1 @ 849CAB4
+	voice_square_2_alt 60, 0, 2, 0, 1, 4, 1 @ 849CAC0
+	voice_square_2_alt 60, 0, 0, 0, 1, 4, 1 @ 849CACC
+	voice_square_1_alt 60, 0, 0, 0, 0, 1, 4, 1 @ 849CAD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CAE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CAF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CAFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CB98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CBA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CBB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CBBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CBC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CBD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CBE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CBEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CBF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CC94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CCA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CCAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CCB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CCC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CCD0
+	voice_noise_alt 60, 0, 0, 0, 2, 4, 0 @ 849CCDC
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0 @ 849CCE8
 
+	.align 2
 voicegroup170:: @ 849CCF4
 	voice_keysplit_all voicegroup001 @ 849CCF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CD9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CDA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CDB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CDC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CDCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CDD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CDE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CDF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CDFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CE98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CEA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CEB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CEBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CEC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CED4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CEE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CEEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CEF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CF04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CF10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CF1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CD9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CDA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CDB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CDC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CDCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CDD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CDE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CDF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CDFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CE98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CEA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CEB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CEBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CEC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CEE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CEEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CEF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CF04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CF10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CF1C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 246, 0, 226 @ 849CF28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CF34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CF40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CF4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CF58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CF64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CF70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CF7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CF88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CF34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CF40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CF4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CF58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CF64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CF70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CF7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CF88
 	voice_keysplit voicegroup005, KeySplitTable3 @ 849CF94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CFA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CFA0
 	voice_keysplit voicegroup006, KeySplitTable4 @ 849CFAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CFB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CFC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CFD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CFDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CFE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849CFF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D000
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D00C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D018
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D024
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D030
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D03C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D048
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CFB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CFC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CFD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CFDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CFE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849CFF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D00C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D03C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D054
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 849D060
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D06C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D078
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D084
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D090
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D09C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D0A8
-	voice_square_2_alt 1, 0, 1, 7, 1 @ 849D0B4
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 7, 15, 1 @ 849D0C0
-	voice_square_1_alt 0, 1, 0, 1, 7, 1 @ 849D0CC
-	voice_square_2_alt 2, 0, 1, 0, 0 @ 849D0D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D06C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D09C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D0A8
+	voice_square_2_alt 60, 0, 1, 0, 1, 7, 1 @ 849D0B4
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 7, 15, 1 @ 849D0C0
+	voice_square_1_alt 60, 0, 0, 1, 0, 1, 7, 1 @ 849D0CC
+	voice_square_2_alt 60, 0, 2, 0, 1, 0, 0 @ 849D0D8
 
+	.align 2
 voicegroup171:: @ 849D0E4
 	voice_keysplit_all voicegroup001 @ 849D0E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D0F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D0FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D108
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D114
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D120
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D12C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D138
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D144
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D150
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D15C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D168
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D174
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D180
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D18C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D198
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D1A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D1B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D1BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D1C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D1D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D1E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D1EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D1F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D204
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D210
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D21C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D228
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D234
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D240
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D24C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D258
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D264
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D270
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D27C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D288
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D294
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D2A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D2AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D2B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D2C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D2D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D2DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D2E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D2F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D0F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D0FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D12C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D15C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D18C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D1A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D1B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D1BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D1C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D1D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D1E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D1EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D1F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D21C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D24C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D27C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D2A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D2AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D2B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D2C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D2D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D2DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D2E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D2F4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_pizzicato_strings, 255, 216, 0, 165 @ 849D300
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D30C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D30C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 246, 0, 226 @ 849D318
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849D324
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D330
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D33C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D348
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D354
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D360
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D36C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D33C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D36C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D378
 	voice_keysplit voicegroup005, KeySplitTable3 @ 849D384
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D390
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D39C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D3A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D39C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D3A8
 	voice_keysplit voicegroup007, KeySplitTable5 @ 849D3B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D3C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D3CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D3D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D3E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D3F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D3FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D408
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D414
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D420
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D42C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D438
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D3C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D3CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D3D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D3E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D3F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D3FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D414
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D420
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D42C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D444
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 849D450
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D45C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D468
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D474
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D480
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D48C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D498
-	voice_square_2_alt 2, 0, 1, 7, 0 @ 849D4A4
-	voice_programmable_wave_alt gProgrammableWaveData_84A323C, 0, 7, 15, 1 @ 849D4B0
-	voice_square_1_alt 0, 2, 0, 1, 7, 0 @ 849D4BC
-	voice_square_2_alt 2, 0, 2, 0, 0 @ 849D4C8
-	voice_square_2_alt 3, 0, 1, 7, 0 @ 849D4D4
-	voice_square_1_alt 0, 3, 0, 1, 7, 0 @ 849D4E0
-	voice_square_1_alt 0, 2, 0, 2, 0, 0 @ 849D4EC
-	voice_square_1_alt 0, 3, 0, 0, 7, 0 @ 849D4F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D504
-	voice_programmable_wave_alt gProgrammableWaveData_84A323C, 0, 7, 15, 0 @ 849D510
-	voice_programmable_wave_alt gProgrammableWaveData_84A324C, 0, 7, 15, 1 @ 849D51C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D45C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D480
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D48C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D498
+	voice_square_2_alt 60, 0, 2, 0, 1, 7, 0 @ 849D4A4
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A323C, 0, 7, 15, 1 @ 849D4B0
+	voice_square_1_alt 60, 0, 0, 2, 0, 1, 7, 0 @ 849D4BC
+	voice_square_2_alt 60, 0, 2, 0, 2, 0, 0 @ 849D4C8
+	voice_square_2_alt 60, 0, 3, 0, 1, 7, 0 @ 849D4D4
+	voice_square_1_alt 60, 0, 0, 3, 0, 1, 7, 0 @ 849D4E0
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 0, 0 @ 849D4EC
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 7, 0 @ 849D4F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D504
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A323C, 0, 7, 15, 0 @ 849D510
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A324C, 0, 7, 15, 1 @ 849D51C
 
+	.align 2
 voicegroup172:: @ 849D528
 	voice_keysplit_all voicegroup002 @ 849D528
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849D534
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D540
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D54C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D54C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226 @ 849D558
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 255, 204, 77, 246 @ 849D564
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D570
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D57C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D588
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D594
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D5A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D5AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D5B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D5C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D5D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D5DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D5E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D57C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D594
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D5A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D5AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D5B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D5C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D5D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D5DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D5E8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 76, 133, 137 @ 849D5F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D600
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D60C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D600
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D60C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D618
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 64, 188, 108, 165 @ 849D624
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D630
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D63C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D63C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 249, 25, 127 @ 849D648
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D654
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D660
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D66C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D678
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D684
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D690
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D69C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D6A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D6B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D6C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D6CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D6D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D6E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D6F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D6FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D708
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D714
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D720
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D72C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D738
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D66C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D69C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D6A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D6B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D6C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D6CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D6D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D6E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D6F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D6FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D720
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D72C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D744
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 246, 0, 235 @ 849D750
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D75C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D75C
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849D768
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D774
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D780
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D78C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D798
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D7A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D7B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D7BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D78C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D7A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D7B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D7BC
 	voice_keysplit voicegroup005, KeySplitTable3 @ 849D7C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D7D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D7E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D7EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D7F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D804
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D810
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D81C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D828
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D834
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D840
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D84C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D858
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D864
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D870
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D87C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D7D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D7E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D7EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D7F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D81C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D84C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D87C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D888
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 849D894
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D8A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D8AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D8B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D8C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D8D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D8DC
-	voice_square_1_alt 0, 1, 0, 2, 5, 2 @ 849D8E8
-	voice_square_2_alt 3, 0, 2, 6, 3 @ 849D8F4
-	voice_square_2_alt 0, 0, 2, 6, 5 @ 849D900
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D90C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D918
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D924
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D930
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D93C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D948
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D954
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D960
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D96C
-	voice_programmable_wave_alt gProgrammableWaveData_84A326C, 0, 0, 12, 0 @ 849D978
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D984
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D990
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D99C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D9A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D9B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D9C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D9CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D9D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D9E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D9F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849D9FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DA98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DAA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DAB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DABC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DAC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DAD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DAE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DAEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DAF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DB04
-	voice_noise_alt 0, 0, 2, 6, 0 @ 849DB10
-	voice_noise_alt 0, 0, 1, 6, 0 @ 849DB1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D8A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D8AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D8B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D8C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D8D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D8DC
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 5, 2 @ 849D8E8
+	voice_square_2_alt 60, 0, 3, 0, 2, 6, 3 @ 849D8F4
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5 @ 849D900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D90C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D93C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D96C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A326C, 0, 0, 12, 0 @ 849D978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D99C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D9A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D9B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D9C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D9CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D9D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D9E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D9F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849D9FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DA98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DAA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DAB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DAC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DAD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DAE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DAEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DAF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DB04
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 849DB10
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 0 @ 849DB1C
 
+	.align 2
 voicegroup173:: @ 849DB28
 	voice_keysplit_all voicegroup002 @ 849DB28
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849DB34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DB40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DB4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DB40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DB4C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226 @ 849DB58
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 128, 204, 77, 246 @ 849DB64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DB70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DB7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DB88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DB94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DBA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DBAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DBB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DBC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DB70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DB7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DB88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DB94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DBA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DBAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DBB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DBC4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 849DBD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DBDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DBE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DBDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DBE8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 51, 0, 203, 127 @ 849DBF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC3C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 249, 25, 127 @ 849DC48
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 64, 216, 51, 224 @ 849DC54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DC9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DCA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DCB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DCC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DC9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DCA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DCB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DCC0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 253, 0, 188 @ 849DCCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DCD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DCE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DCF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DCFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DCD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DCE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DCF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DCFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD5C
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849DD68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DD98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DDA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DDB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DDBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DDC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DDD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DDE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DDEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DDF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DE88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DD98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DDA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DDB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DDBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DDC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DDD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DDE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DDEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DDF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DE88
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 849DE94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DEA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DEAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DEB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DEC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DED0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DEDC
-	voice_square_1_alt 0, 1, 0, 2, 3, 4 @ 849DEE8
-	voice_square_2_alt 3, 0, 3, 3, 2 @ 849DEF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF6C
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849DF78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DF9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DFA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DFB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DFC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DFCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DFD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DFE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DFF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849DFFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E008
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E014
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E020
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E02C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E038
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E044
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E050
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E05C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E068
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E074
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E080
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E08C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E098
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E0A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E0B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E0BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E0C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E0D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E0E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E0EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E0F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E104
-	voice_noise_alt 0, 0, 2, 6, 0 @ 849E110
-	voice_noise_alt 0, 0, 1, 3, 2 @ 849E11C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DEA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DEAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DEB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DEC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DEDC
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 3, 4 @ 849DEE8
+	voice_square_2_alt 60, 0, 3, 0, 3, 3, 2 @ 849DEF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF6C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849DF78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DF9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DFA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DFB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DFC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DFCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DFD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DFE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DFF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849DFFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E008
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E02C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E05C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E08C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E0A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E0B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E0BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E0C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E0D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E0E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E0EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E0F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E104
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 849E110
+	voice_noise_alt 60, 0, 0, 0, 1, 3, 2 @ 849E11C
 
+	.align 2
 voicegroup174:: @ 849E128
 	voice_keysplit_all voicegroup002 @ 849E128
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849E134
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E140
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E14C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E14C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E158
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165 @ 849E164
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E170
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E17C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E188
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E194
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E1A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E1AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E1B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E1C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E1D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E1DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E1E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E170
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E17C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E194
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E1A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E1AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E1B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E1C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E1D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E1DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E1E8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 0, 255, 127 @ 849E1F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E200
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E20C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E20C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E218
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 255, 0, 255, 165 @ 849E224
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E230
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E23C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E248
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E254
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E260
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E26C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E23C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E248
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E26C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E278
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 128, 0, 255, 214 @ 849E284
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 128, 0, 255, 206 @ 849E290
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E29C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E2A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E2B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E2C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E2CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E2D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E2E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E29C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E2A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E2B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E2C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E2CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E2D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E2E4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 255, 252, 0, 165 @ 849E2F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E2FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E308
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E314
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E320
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E32C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E338
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E344
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E350
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E35C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E2FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E32C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E35C
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849E368
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E374
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E380
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E38C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E398
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E3A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E3B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E3BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E38C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E3A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E3B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E3BC
 	voice_keysplit voicegroup005, KeySplitTable3 @ 849E3C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E3D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E3E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E3EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E3D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E3E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E3EC
 	voice_keysplit voicegroup007, KeySplitTable5 @ 849E3F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E404
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 209 @ 849E410
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E41C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E428
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E434
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E440
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E44C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E458
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E464
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E470
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E47C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E488
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E494
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E4A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E4AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E4B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E4C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E4D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E4DC
-	voice_square_1_alt 0, 3, 0, 2, 3, 4 @ 849E4E8
-	voice_square_2_alt 3, 0, 2, 3, 4 @ 849E4F4
-	voice_square_1_alt 0, 3, 0, 2, 3, 4 @ 849E500
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E50C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E518
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E524
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E530
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E53C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E548
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E554
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E560
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E56C
-	voice_programmable_wave_alt gProgrammableWaveData_84A31FC, 0, 7, 15, 0 @ 849E578
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E584
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E590
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E59C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E5A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E5B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E5C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E5CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E5D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E5E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E5F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E5FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E608
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E614
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E620
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E62C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E638
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E644
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E650
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E65C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E668
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E674
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E680
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E68C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E698
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E6A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E6B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E6BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E41C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E44C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E47C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E4A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E4AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E4B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E4C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E4D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E4DC
+	voice_square_1_alt 60, 0, 0, 3, 0, 2, 3, 4 @ 849E4E8
+	voice_square_2_alt 60, 0, 3, 0, 2, 3, 4 @ 849E4F4
+	voice_square_1_alt 60, 0, 0, 3, 0, 2, 3, 4 @ 849E500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E50C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E53C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E56C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31FC, 0, 7, 15, 0 @ 849E578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E59C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E5A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E5B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E5C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E5CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E5D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E5E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E5F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E5FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E614
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E62C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E65C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E68C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E6A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E6B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E6BC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165 @ 849E6C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E6D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E6E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E6EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E6F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E704
-	voice_noise_alt 0, 0, 2, 6, 0 @ 849E710
-	voice_noise_alt 0, 0, 1, 3, 1 @ 849E71C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E6D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E6E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E6EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E6F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E704
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 849E710
+	voice_noise_alt 60, 0, 0, 0, 1, 3, 1 @ 849E71C
 	voice_keysplit_all voicegroup177 @ 849E728
-	voice_square_1_alt 0, 2, 0, 2, 9, 1 @ 849E734
-	voice_square_2_alt 2, 0, 2, 9, 1 @ 849E740
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849E74C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E758
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E764
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E770
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E77C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E788
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E794
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E7A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E7AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E7B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E7C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E7D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E7DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E7E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E7F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E800
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E80C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E818
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E824
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E830
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E83C
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 9, 1 @ 849E734
+	voice_square_2_alt 60, 0, 2, 0, 2, 9, 1 @ 849E740
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849E74C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E77C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E7A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E7AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E7B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E7C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E7D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E7DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E7E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E7F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E80C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E83C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 165, 154, 127 @ 849E848
 	voice_keysplit_all voicegroup002 @ 849E854
-	voice_square_1_alt 0, 2, 0, 2, 3, 1 @ 849E860
-	voice_square_2_alt 2, 0, 2, 3, 1 @ 849E86C
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849E878
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 3, 1 @ 849E860
+	voice_square_2_alt 60, 0, 2, 0, 2, 3, 1 @ 849E86C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849E878
 
+	.align 2
 voicegroup175:: @ 849E884
 	voice_keysplit_all voicegroup177 @ 849E884
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E890
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E89C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E8A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E8B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E8C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E8CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E8D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E8E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E8F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E8FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E908
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E89C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E8A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E8B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E8C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E8CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E8D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E8E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E8F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E8FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E914
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_xylophone, 255, 235, 0, 204 @ 849E920
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E92C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E938
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E944
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E950
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E95C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E968
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E974
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E980
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E98C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E92C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E95C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E98C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E998
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 85, 165, 154, 127 @ 849E9A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E9B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E9BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E9C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E9D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E9E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E9EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849E9F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EA94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EAA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EAAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EAB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EAC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EAD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EADC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EAE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E9B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E9BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E9C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E9D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E9E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E9EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849E9F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EA94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EAA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EAAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EAB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EAC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EAD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EAE8
 
+	.align 2
 voicegroup176:: @ 849EAF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EAF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EB9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EBA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EBB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EBC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EBCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EBD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EBE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EBF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EBFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EC08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EC14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EC20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EC2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EC38
-	voice_square_1_alt 0, 2, 0, 2, 7, 1 @ 849EC44
-	voice_square_2_alt 2, 0, 2, 9, 1 @ 849EC50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EC5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EC68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EC74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EC80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EC8C
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 849EC98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ECA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ECB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ECBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ECC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ECD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ECE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ECEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ECF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EAF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EB9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EBA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EBB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EBC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EBCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EBD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EBE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EBF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EBFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EC08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EC14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EC20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EC2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EC38
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 7, 1 @ 849EC44
+	voice_square_2_alt 60, 0, 2, 0, 2, 9, 1 @ 849EC50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EC5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EC68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EC74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EC80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EC8C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 849EC98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ECA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ECB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ECBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ECC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ECD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ECE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ECEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ECF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED28
 
+	.align 2
 voicegroup177:: @ 849ED34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849ED94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EDA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EDAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EDB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EDC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EDD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EDDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EDE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EDF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EE9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EEA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EEB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EEC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849ED94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EDA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EDAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EDB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EDC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EDD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EDDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EDE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EDF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EE9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EEA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EEB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EEC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EECC
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88pro_jingle_bell, 255, 0, 255, 0 @ 849EED8
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_drum_and_percussion_kick, 255, 0, 255, 0 @ 849EEE4
 	voice_directsound_no_resample 67, 71, DirectSoundWaveData_sd90_solo_snare, 255, 180, 175, 228 @ 849EEF0
@@ -7354,1422 +7417,1435 @@ voicegroup177:: @ 849ED34
 	voice_directsound_no_resample 65, 0, DirectSoundWaveData_sc88pro_tr909_hand_clap, 255, 255, 255, 127 @ 849EF08
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88pro_orchestra_snare, 255, 0, 255, 242 @ 849EF14
 	voice_directsound 64, 24, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226 @ 849EF20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EF2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EF2C
 	voice_directsound 68, 29, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226 @ 849EF38
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88pro_rnd_snare, 255, 0, 255, 242 @ 849EF44
 	voice_directsound 72, 64, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226 @ 849EF50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EF5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EF5C
 	voice_directsound 76, 39, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226 @ 849EF68
 	voice_directsound 80, 89, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 226 @ 849EF74
 	voice_directsound_no_resample 33, 10, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 849EF80
 	voice_directsound 84, 104, DirectSoundWaveData_sd90_ambient_tom, 255, 0, 255, 235 @ 849EF8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EF98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EF98
 	voice_directsound 63, 64, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 849EFA4
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_dance_drums_ride_bell, 255, 165, 103, 231 @ 849EFB0
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88pro_tambourine, 255, 127, 77, 204 @ 849EFBC
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_trinity_cymbal_crash, 255, 231, 0, 188 @ 849EFC8
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sd90_cowbell, 255, 0, 255, 242 @ 849EFD4
 	voice_directsound_no_resample 64, 118, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 849EFE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849EFEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849EFEC
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 849EFF8
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 8, 0, 255, 216 @ 849F004
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_unused_heart_of_asia_indian_drum, 255, 0, 255, 0 @ 849F010
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88pro_mute_high_conga, 255, 0, 255, 0 @ 849F01C
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88pro_open_low_conga, 255, 0, 255, 0 @ 849F028
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88pro_open_low_conga, 255, 0, 255, 0 @ 849F034
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F040
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F04C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F058
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F064
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F070
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F07C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F088
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F094
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F0A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F0AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F0B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F0C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F0D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F0DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F0E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F04C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F07C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F0A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F0AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F0B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F0C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F0D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F0DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F0E8
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sd90_open_triangle, 255, 242, 103, 188 @ 849F0F4
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sd90_open_triangle, 255, 242, 103, 188 @ 849F100
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sd90_open_triangle, 255, 165, 103, 188 @ 849F10C
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88pro_jingle_bell, 255, 0, 255, 0 @ 849F118
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F124
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F130
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_ethnic_flavours_atarigane, 255, 0, 255, 0 @ 849F13C
 	voice_directsound 63, 64, DirectSoundWaveData_sc88pro_taiko, 255, 0, 255, 0 @ 849F148
 	voice_directsound 50, 64, DirectSoundWaveData_ethnic_flavours_kotsuzumi, 255, 0, 255, 0 @ 849F154
 	voice_directsound 64, 64, DirectSoundWaveData_ethnic_flavours_kotsuzumi, 255, 0, 255, 0 @ 849F160
 
+	.align 2
 voicegroup178:: @ 849F16C
 	voice_keysplit_all voicegroup177 @ 849F16C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F178
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F184
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F190
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F19C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F1A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F1B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F1C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F1CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F1D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F1E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F1F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F1FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F19C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F1A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F1B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F1C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F1CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F1D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F1E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F1F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F1FC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_xylophone, 255, 204, 103, 165 @ 849F208
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F214
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F220
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F22C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F238
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F244
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F250
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F25C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F268
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F274
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F214
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F22C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F238
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F244
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F25C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F280
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 165, 154, 165 @ 849F28C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F298
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F2A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F2B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F2BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F2C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F2D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F2E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F2EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F2F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F304
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F310
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F31C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F328
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F334
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F340
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F34C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F358
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F364
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F370
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F37C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F388
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F394
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F3A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F3AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F3B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F3C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F3D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F3DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F3E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F3F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F400
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F40C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F418
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F424
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F430
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F43C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F448
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F454
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F460
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F46C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F478
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F484
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F490
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F49C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F4A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F4B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F4C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F4CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F4D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F4E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F4F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F4FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F508
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F514
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F520
-	voice_square_1_alt 0, 2, 0, 2, 7, 1 @ 849F52C
-	voice_square_2_alt 2, 0, 2, 7, 1 @ 849F538
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F544
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F550
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F55C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F568
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F574
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 0, 15, 1 @ 849F580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F2A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F2B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F2BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F2C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F2D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F2E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F2EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F2F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F31C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F328
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F334
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F34C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F37C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F3A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F3AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F3B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F3C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F3D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F3DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F3E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F3F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F40C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F43C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F448
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F46C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F49C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F4A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F4B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F4C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F4CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F4D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F4E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F4F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F4FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F520
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 7, 1 @ 849F52C
+	voice_square_2_alt 60, 0, 2, 0, 2, 7, 1 @ 849F538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F55C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F574
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 0, 15, 1 @ 849F580
 
+	.align 2
 voicegroup179:: @ 849F58C
 	voice_keysplit_all voicegroup177 @ 849F58C
 	voice_keysplit_all voicegroup176 @ 849F598
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849F5A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F5B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F5BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F5C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F5D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F5E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F5EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F5F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F604
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F610
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F61C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F5B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F5BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F5C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F5D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F5E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F5EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F5F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F61C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_xylophone, 255, 235, 0, 204 @ 849F628
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F634
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F640
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F64C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F658
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F664
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F670
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F67C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F688
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F694
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F6A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F64C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F67C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F6A0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 85, 165, 154, 127 @ 849F6AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F6B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F6C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F6D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F6DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F6E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F6F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F700
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F70C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F6B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F6C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F6D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F6DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F6E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F6F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F70C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fingered_bass, 255, 253, 0, 149 @ 849F718
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F724
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F730
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F73C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F748
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F754
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F760
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F76C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F778
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F784
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F790
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F79C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F7A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F7B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F7C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F73C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F76C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F79C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F7A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F7B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F7C0
 	voice_keysplit voicegroup004, KeySplitTable2 @ 849F7CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F7D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F7E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F7F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F7FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F808
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F814
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F7D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F7E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F7F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F7FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F808
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F814
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F820
 	voice_keysplit voicegroup005, KeySplitTable3 @ 849F82C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F838
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F838
 	voice_keysplit voicegroup006, KeySplitTable4 @ 849F844
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F850
 	voice_keysplit voicegroup007, KeySplitTable5 @ 849F85C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F868
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F874
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F880
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F88C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F898
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F8A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F8B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F8BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F8C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F8D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F8E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F8EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F8F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F904
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F910
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F91C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F928
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F934
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F940
-	voice_square_1_alt 0, 3, 0, 0, 10, 0 @ 849F94C
-	voice_square_2_alt 0, 0, 1, 9, 0 @ 849F958
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F964
-	voice_square_2_alt 3, 0, 1, 9, 0 @ 849F970
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F97C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F988
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F994
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 849F9A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F88C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F8A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F8B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F8BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F8C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F8D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F8E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F8EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F8F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F91C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F928
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F934
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F940
+	voice_square_1_alt 60, 0, 0, 3, 0, 0, 10, 0 @ 849F94C
+	voice_square_2_alt 60, 0, 0, 0, 1, 9, 0 @ 849F958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F964
+	voice_square_2_alt 60, 0, 3, 0, 1, 9, 0 @ 849F970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F97C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F994
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 7, 15, 0 @ 849F9A0
 
+	.align 2
 voicegroup180:: @ 849F9AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F9AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F9AC
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849F9B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F9C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F9D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F9C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F9D0
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 64, 249, 0, 188 @ 849F9DC
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 249, 0, 165 @ 849F9E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849F9F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FA9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FAA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FAB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FAC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FACC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FAD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FAE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FAF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FAFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FB98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FBA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FBB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FBBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FBC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FBD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FBE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FBEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FBF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FC94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FCA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FCAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FCB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FCC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FCD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FCDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FCE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FCF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD60
-	voice_square_1_alt 0, 2, 0, 2, 3, 1 @ 849FD6C
-	voice_square_2_alt 2, 0, 2, 3, 1 @ 849FD78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FD9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FDA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FDB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FDC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FDCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FDD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FDE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FDF0
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849FDFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FE98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FEA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FEB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FEBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FEC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FED4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FEE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FEEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FEF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FF88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849F9F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FA9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FAA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FAB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FAC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FAD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FAE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FAF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FAFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FB98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FBA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FBB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FBBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FBC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FBD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FBE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FBEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FBF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FC94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FCA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FCAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FCB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FCC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FCD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FCDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FCE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FCF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD60
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 3, 1 @ 849FD6C
+	voice_square_2_alt 60, 0, 2, 0, 2, 3, 1 @ 849FD78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FD9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FDA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FDB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FDC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FDCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FDD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FDE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FDF0
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 849FDFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FE98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FEA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FEB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FEBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FEC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FEE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FEEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FEF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FF88
 	voice_directsound_no_resample 60, 0, DirectSoundWaveData_sc88pro_tr909_hand_clap, 255, 255, 255, 127 @ 849FF94
-	voice_noise_alt 0, 0, 1, 0, 0 @ 849FFA0
+	voice_noise_alt 60, 0, 0, 0, 1, 0, 0 @ 849FFA0
 
+	.align 2
 voicegroup181:: @ 849FFAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FFAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FFAC
 	voice_keysplit voicegroup003, KeySplitTable1 @ 849FFB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FFC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FFD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FFDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FFE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 849FFF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0000
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A000C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0018
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0024
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0030
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A003C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0048
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0054
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0060
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A006C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0078
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0084
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0090
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A009C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A00A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A00B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A00C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A00CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A00D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A00E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A00F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A00FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0108
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0114
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0120
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A012C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0138
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0144
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0150
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A015C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0168
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0174
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0180
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A018C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0198
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A01A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A01B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A01BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A01C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FFC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FFD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FFDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FFE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 849FFF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A000C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0018
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0024
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0030
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A003C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0060
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A006C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0078
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0084
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0090
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A009C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A00A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A00B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A00C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A00CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A00D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A00E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A00F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A00FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0108
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0114
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0120
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A012C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0138
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0144
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0150
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A015C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0168
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0174
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0180
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A018C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0198
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A01A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A01B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A01BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A01C8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 242, 51, 242 @ 84A01D4
 
+	.align 2
 voicegroup182:: @ 84A01E0
 	voice_keysplit_all voicegroup002 @ 84A01E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A01EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A01F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0204
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0210
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A021C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0228
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0234
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0240
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A024C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0258
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0264
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0270
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A027C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0288
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0294
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A02A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A02AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A02B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A02C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A02D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A02DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A02E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A02F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0300
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A030C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0318
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0324
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0330
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A033C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0348
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0354
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0360
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A036C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0378
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0384
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0390
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A039C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A03A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A03B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A03C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A03CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A03D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A03E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A03F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A03FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0408
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A01EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A01F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0204
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0210
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A021C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0228
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0234
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0240
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A024C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0258
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0264
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0270
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A027C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0288
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0294
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A02A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A02AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A02B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A02C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A02D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A02DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A02E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A02F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0300
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A030C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0318
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0324
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0330
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A033C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0348
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0354
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0360
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A036C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0378
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0384
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0390
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A039C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A03A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A03B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A03C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A03CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A03D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A03E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A03F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A03FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0408
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 0, 193, 76 @ 84A0414
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84A0420
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A042C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0438
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0444
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0450
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A045C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0468
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0474
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A042C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0438
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0444
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0450
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A045C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0468
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0474
 	voice_keysplit voicegroup005, KeySplitTable3 @ 84A0480
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A048C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A048C
 	voice_keysplit voicegroup006, KeySplitTable4 @ 84A0498
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A04A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A04A4
 	voice_keysplit voicegroup007, KeySplitTable5 @ 84A04B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A04BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A04C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A04D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A04E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A04EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A04F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0504
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0510
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A051C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0528
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0534
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0540
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A054C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0558
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0564
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0570
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A057C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0588
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0594
-	voice_square_1_alt 0, 1, 1, 2, 3, 1 @ 84A05A0
-	voice_square_2_alt 1, 0, 2, 6, 2 @ 84A05AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A05B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A05C4
-	voice_square_1_alt 0, 0, 0, 2, 3, 1 @ 84A05D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A05DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A05E8
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84A05F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A04BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A04C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A04D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A04E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A04EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A04F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0504
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0510
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A051C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0528
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0534
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0540
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A054C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0558
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0564
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0570
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A057C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0588
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0594
+	voice_square_1_alt 60, 0, 0, 1, 1, 2, 3, 1 @ 84A05A0
+	voice_square_2_alt 60, 0, 1, 0, 2, 6, 2 @ 84A05AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A05B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A05C4
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 3, 1 @ 84A05D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A05DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A05E8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84A05F4
 
+	.align 2
 voicegroup183:: @ 84A0600
 	voice_keysplit_all voicegroup002 @ 84A0600
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A060C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0618
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0624
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0630
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A063C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0648
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0654
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0660
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A066C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0678
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0684
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0690
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A069C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A06A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A06B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A06C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A06CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A06D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A06E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A06F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A06FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0708
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0714
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A060C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0618
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0624
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0630
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A063C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0648
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0654
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0660
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A066C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0678
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0684
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0690
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A069C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A06A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A06B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A06C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A06CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A06D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A06E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A06F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A06FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0708
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0714
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 249, 25, 127 @ 84A0720
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A072C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0738
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0744
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0750
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A075C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0768
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0774
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0780
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A078C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0798
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A072C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0738
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0744
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0750
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A075C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0768
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0774
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0780
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A078C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0798
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 253, 0, 188 @ 84A07A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A07B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A07BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A07C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A07D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A07E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A07EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A07F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0804
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0810
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A081C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0828
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0834
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0840
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A084C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0858
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0864
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0870
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A087C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0888
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0894
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A08A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A08AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A08B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A08C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A08D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A08DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A08E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A08F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0900
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A090C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0918
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0924
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0930
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A093C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0948
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0954
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0960
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A096C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0978
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0984
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0990
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A099C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A09A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A09B4
-	voice_square_1_alt 0, 2, 0, 2, 4, 1 @ 84A09C0
-	voice_square_2_alt 2, 0, 2, 4, 1 @ 84A09CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A09D8
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84A09E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A09F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A09FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0A98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0AA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0AB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0ABC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0AC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0AD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0AE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0AEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0AF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0B94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0BA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0BAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0BB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0BC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0BD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0BDC
-	voice_noise_alt 0, 0, 2, 6, 0 @ 84A0BE8
-	voice_noise_alt 0, 0, 1, 3, 1 @ 84A0BF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A07B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A07BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A07C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A07D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A07E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A07EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A07F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0804
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0810
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A081C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0828
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0834
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0840
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A084C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0858
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0864
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0870
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A087C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0888
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0894
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A08A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A08AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A08B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A08C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A08D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A08DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A08E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A08F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0900
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A090C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0918
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0924
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0930
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A093C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0948
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0954
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0960
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A096C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0978
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0984
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0990
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A099C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A09A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A09B4
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 4, 1 @ 84A09C0
+	voice_square_2_alt 60, 0, 2, 0, 2, 4, 1 @ 84A09CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A09D8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84A09E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A09F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A09FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0A98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0AA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0AB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0ABC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0AC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0AD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0AE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0AEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0AF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0B94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0BA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0BAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0BB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0BC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0BD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0BDC
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 84A0BE8
+	voice_noise_alt 60, 0, 0, 0, 1, 3, 1 @ 84A0BF4
 
+	.align 2
 voicegroup184:: @ 84A0C00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C18
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84A0C24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0C9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C18
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84A0C24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0C9C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 84A0CA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0CB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0CC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0CCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0CD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0CE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0CF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0CFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0CB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0CC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0CCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0CD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0CE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0CF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0CFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D68
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165 @ 84A0D74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0D98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0DA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0DB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0DBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0D98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0DA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0DB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0DBC
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 255, 252, 0, 115 @ 84A0DC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0DD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0DE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0DEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0DF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0E94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0EA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0EAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0EB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0EC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0ED0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0EDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0EE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0EF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0F9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0FA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0FB4
-	voice_square_2_alt 3, 0, 0, 15, 0 @ 84A0FC0
-	voice_square_1_alt 0, 2, 0, 0, 15, 0 @ 84A0FCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0FD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0FE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A0FF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0DD4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0DE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0DEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0DF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0E94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0EA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0EAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0EB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0EC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0ED0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0EDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0EE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0EF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0F9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0FA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0FB4
+	voice_square_2_alt 60, 0, 3, 0, 0, 15, 0 @ 84A0FC0
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0FCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0FD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0FE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A0FF0
 	voice_directsound 60, 0, DirectSoundWaveData_classical_choir_voice_ahhs, 255, 0, 255, 0 @ 84A0FFC
 
+	.align 2
 voicegroup185:: @ 84A1008
 	voice_keysplit_all voicegroup002 @ 84A1008
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1014
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1020
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A102C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1038
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1044
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1050
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A105C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1068
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1074
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1080
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A108C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1098
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A10A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1014
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1020
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A102C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1038
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1044
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1050
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A105C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1068
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1074
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1080
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A108C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1098
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A10A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 84A10B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A10BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A10C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A10D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A10E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A10EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A10F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1104
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1110
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A111C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1128
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1134
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1140
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A114C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1158
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A10BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A10C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A10D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A10E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A10EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A10F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1104
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1110
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A111C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1128
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1134
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1140
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A114C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1158
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_overdrive_guitar, 128, 0, 255, 214 @ 84A1164
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_high, 128, 0, 255, 206 @ 84A1170
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_special_scream_drive, 255, 0, 255, 165 @ 84A117C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1188
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1188
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fingered_bass, 255, 253, 0, 149 @ 84A1194
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A11A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A11A0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 253, 0, 188 @ 84A11AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A11B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A11C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A11B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A11C4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_synth_bass, 255, 252, 0, 115 @ 84A11D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A11DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A11E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A11F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1200
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A120C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1218
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A11DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A11E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A11F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1200
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A120C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1218
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_pizzicato_strings, 255, 216, 0, 165 @ 84A1224
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1230
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1230
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_timpani, 255, 246, 0, 226 @ 84A123C
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84A1248
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1254
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1260
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A126C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1278
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1254
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1260
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A126C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1278
 	voice_directsound 60, 0, DirectSoundWaveData_classical_choir_voice_ahhs, 85, 0, 154, 165 @ 84A1284
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1290
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A129C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1290
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A129C
 	voice_keysplit voicegroup005, KeySplitTable3 @ 84A12A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A12B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A12C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A12CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A12B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A12C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A12CC
 	voice_keysplit voicegroup007, KeySplitTable5 @ 84A12D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A12E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A12E4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_distortion_guitar_low, 255, 0, 255, 209 @ 84A12F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A12FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1308
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1314
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1320
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A132C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1338
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1344
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1350
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A135C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1368
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1374
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1380
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A138C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1398
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A13A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A12FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1308
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1314
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1320
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A132C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1338
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1344
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1350
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A135C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1368
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1374
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1380
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A138C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1398
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A13A4
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_whistle, 255, 0, 255, 127 @ 84A13B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A13BC
-	voice_square_2_alt 2, 0, 0, 15, 0 @ 84A13C8
-	voice_square_1_alt 0, 2, 0, 0, 15, 0 @ 84A13D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A13E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A13EC
-	voice_programmable_wave_alt gProgrammableWaveData_84A328C, 0, 7, 15, 0 @ 84A13F8
-	voice_programmable_wave_alt gProgrammableWaveData_84A327C, 0, 7, 15, 0 @ 84A1404
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1410
-	voice_programmable_wave_alt gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84A141C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1428
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1434
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1440
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A144C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1458
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1464
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1470
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A147C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1488
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1494
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A14A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A14AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A14B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A14C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A14D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A14DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A14E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A14F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1500
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A150C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1518
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1524
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1530
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A153C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1548
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1554
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1560
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A156C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1578
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1584
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1590
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A159C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A15A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A15B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A15C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A15CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A15D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A15E4
-	voice_noise_alt 0, 0, 2, 6, 0 @ 84A15F0
-	voice_noise_alt 0, 0, 1, 6, 1 @ 84A15FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A13BC
+	voice_square_2_alt 60, 0, 2, 0, 0, 15, 0 @ 84A13C8
+	voice_square_1_alt 60, 0, 0, 2, 0, 0, 15, 0 @ 84A13D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A13E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A13EC
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A328C, 0, 7, 15, 0 @ 84A13F8
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A327C, 0, 7, 15, 0 @ 84A1404
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1410
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A322C, 0, 7, 15, 0 @ 84A141C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1428
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1434
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1440
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A144C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1458
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1464
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1470
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A147C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1488
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1494
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A14A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A14AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A14B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A14C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A14D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A14DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A14E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A14F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1500
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A150C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1518
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1524
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1530
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A153C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1548
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1554
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1560
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A156C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1578
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1584
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1590
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A159C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A15A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A15B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A15C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A15CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A15D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A15E4
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 84A15F0
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1 @ 84A15FC
 
+	.align 2
 voicegroup186:: @ 84A1608
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1608
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1608
 	voice_keysplit voicegroup003, KeySplitTable1 @ 84A1614
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1620
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A162C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1638
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1644
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1650
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A165C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1668
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1674
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1680
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A168C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1698
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A16A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A16B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A16BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A16C8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A16D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A16E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A16EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A16F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1704
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1710
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A171C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1728
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1734
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1740
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A174C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1758
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1764
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1770
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A177C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1788
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1794
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A17A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A17AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A17B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A17C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A17D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A17DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A17E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A17F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1800
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A180C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1818
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1824
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1830
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A183C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1848
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1854
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1860
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A186C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1878
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1884
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1890
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A189C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A18A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A18B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A18C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A18CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A18D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A18E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A18F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A18FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1908
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1914
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1920
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A192C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1938
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1944
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1950
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A195C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1968
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1974
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1980
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A198C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1998
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A19A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A19B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A19BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A19C8
-	voice_square_2_alt 3, 0, 0, 15, 0 @ 84A19D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A19E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A19EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A19F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1A94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1AA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1AAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1AB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1AC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1AD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1ADC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1AE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1AF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1B9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1BA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1BB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1BC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1BCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1BD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1BE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1BF0
-	voice_noise_alt 0, 0, 2, 6, 0 @ 84A1BFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1620
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A162C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1638
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1644
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1650
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A165C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1668
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1674
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1680
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A168C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1698
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A16A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A16B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A16BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A16C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A16D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A16E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A16EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A16F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1704
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1710
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A171C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1728
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1734
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1740
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A174C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1758
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1764
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1770
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A177C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1788
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1794
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A17A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A17AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A17B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A17C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A17D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A17DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A17E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A17F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1800
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A180C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1818
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1824
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1830
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A183C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1848
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1854
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1860
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A186C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1878
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1884
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1890
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A189C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A18A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A18B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A18C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A18CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A18D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A18E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A18F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A18FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1908
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1914
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1920
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A192C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1938
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1944
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1950
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A195C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1968
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1974
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1980
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A198C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1998
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A19A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A19B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A19BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A19C8
+	voice_square_2_alt 60, 0, 3, 0, 0, 15, 0 @ 84A19D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A19E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A19EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A19F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1A94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1AA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1AAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1AB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1AC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1AD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1ADC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1AE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1AF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1B9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1BA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1BB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1BC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1BCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1BD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1BE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1BF0
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 84A1BFC
 
+	.align 2
 voicegroup187:: @ 84A1C08
 	voice_keysplit_all voicegroup002 @ 84A1C08
 	voice_keysplit voicegroup003, KeySplitTable1 @ 84A1C14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1C20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1C2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1C38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1C44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1C50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1C5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1C68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1C74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1C80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1C8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1C98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1CA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1CB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1CBC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1CC8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1C20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1C2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1C38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1C44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1C50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1C5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1C68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1C74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1C80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1C8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1C98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1CA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1CB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1CBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1CC8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 255, 76, 133, 137 @ 84A1CD4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1CE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1CEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1CF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1CE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1CEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1CF8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_accordion, 64, 188, 108, 165 @ 84A1D04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1D10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1D1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1D10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1D1C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 255, 249, 25, 127 @ 84A1D28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1D34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1D40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1D4C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1D58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1D64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1D70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1D7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1D88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1D94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1DA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1DAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1DB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1DC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1DD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1DDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1DE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1DF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1D34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1D40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1D4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1D58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1D64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1D70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1D7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1D88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1D94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1DA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1DAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1DB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1DC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1DD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1DDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1DE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1DF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E24
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_harp, 255, 246, 0, 235 @ 84A1E30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E3C
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84A1E48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1E9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1E9C
 	voice_keysplit voicegroup005, KeySplitTable3 @ 84A1EA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1EB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1EC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1ECC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1EB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1EC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1ECC
 	voice_keysplit voicegroup007, KeySplitTable5 @ 84A1ED8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1EE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1EF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1EFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1EE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1EF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1EFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F68
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 84A1F74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1F98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1FA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1FB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1FBC
-	voice_square_1_alt 0, 0, 0, 2, 5, 2 @ 84A1FC8
-	voice_square_2_alt 1, 0, 1, 7, 1 @ 84A1FD4
-	voice_square_2_alt 0, 0, 2, 6, 5 @ 84A1FE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1FEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A1FF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2004
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2010
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A201C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2028
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2034
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2040
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A204C
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 0, 12, 0 @ 84A2058
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2064
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2070
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A207C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2088
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2094
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A20A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A20AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A20B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A20C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A20D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A20DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A20E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A20F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2100
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A210C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2118
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2124
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2130
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A213C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2148
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2154
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2160
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A216C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2178
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2184
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2190
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A219C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A21A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A21B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A21C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A21CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A21D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A21E4
-	voice_noise_alt 0, 0, 2, 6, 0 @ 84A21F0
-	voice_noise_alt 0, 0, 1, 6, 1 @ 84A21FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1F98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1FA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1FB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1FBC
+	voice_square_1_alt 60, 0, 0, 0, 0, 2, 5, 2 @ 84A1FC8
+	voice_square_2_alt 60, 0, 1, 0, 1, 7, 1 @ 84A1FD4
+	voice_square_2_alt 60, 0, 0, 0, 2, 6, 5 @ 84A1FE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1FEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A1FF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2004
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2010
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A201C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2028
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2034
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2040
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A204C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 0, 12, 0 @ 84A2058
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2064
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2070
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A207C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2088
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2094
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A20A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A20AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A20B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A20C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A20D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A20DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A20E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A20F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2100
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A210C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2118
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2124
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2130
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A213C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2148
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2154
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2160
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A216C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2178
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2184
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2190
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A219C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A21A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A21B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A21C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A21CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A21D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A21E4
+	voice_noise_alt 60, 0, 0, 0, 2, 6, 0 @ 84A21F0
+	voice_noise_alt 60, 0, 0, 0, 1, 6, 1 @ 84A21FC
 
+	.align 2
 voicegroup188:: @ 84A2208
 	voice_keysplit_all voicegroup002 @ 84A2208
 	voice_keysplit voicegroup003, KeySplitTable1 @ 84A2214
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2220
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A222C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2220
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A222C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226 @ 84A2238
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 128, 204, 77, 246 @ 84A2244
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2250
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A225C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2268
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2274
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2280
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A228C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2298
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A22A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2250
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A225C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2268
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2274
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2280
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A228C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2298
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A22A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 84A22B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A22BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A22C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A22BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A22C8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 51, 0, 203, 127 @ 84A22D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A22E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A22EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A22F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2304
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2310
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A231C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A22E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A22EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A22F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2304
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2310
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A231C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 249, 25, 127 @ 84A2328
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 64, 216, 51, 224 @ 84A2334
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2340
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A234C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2358
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2364
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2370
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A237C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2388
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2394
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A23A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2340
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A234C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2358
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2364
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2370
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A237C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2388
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2394
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A23A0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 253, 0, 188 @ 84A23AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A23B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A23C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A23D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A23DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A23E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A23F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2400
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A240C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2418
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2424
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2430
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A243C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A23B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A23C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A23D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A23DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A23E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A23F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2400
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A240C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2418
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2424
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2430
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A243C
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84A2448
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2454
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2460
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A246C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2478
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2484
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2490
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A249C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A24A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A24B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A24C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A24CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A24D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A24E4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A24F0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A24FC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2508
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2514
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2520
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A252C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2538
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2544
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2550
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A255C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2568
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2454
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2460
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A246C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2478
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2484
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2490
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A249C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A24A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A24B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A24C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A24CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A24D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A24E4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A24F0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A24FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2508
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2514
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2520
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A252C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2538
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2544
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2550
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A255C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2568
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 84A2574
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2580
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A258C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2598
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A25A4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A25B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A25BC
-	voice_square_1_alt 0, 1, 0, 2, 6, 1 @ 84A25C8
-	voice_square_2_alt 3, 0, 3, 3, 2 @ 84A25D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A25E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A25EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A25F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2604
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2610
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A261C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2628
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2634
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2640
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A264C
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 7, 15, 2 @ 84A2658
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2664
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2670
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A267C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2688
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2694
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A26A0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A26AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A26B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A26C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A26D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A26DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A26E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A26F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2700
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A270C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2718
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2724
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2730
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A273C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2748
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2754
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2760
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A276C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2778
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2784
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2790
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A279C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A27A8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A27B4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A27C0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A27CC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A27D8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A27E4
-	voice_noise_alt 0, 0, 2, 7, 0 @ 84A27F0
-	voice_noise_alt 0, 0, 1, 9, 1 @ 84A27FC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2580
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A258C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2598
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A25A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A25B0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A25BC
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 6, 1 @ 84A25C8
+	voice_square_2_alt 60, 0, 3, 0, 3, 3, 2 @ 84A25D4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A25E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A25EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A25F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2604
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2610
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A261C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2628
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2634
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2640
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A264C
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 7, 15, 2 @ 84A2658
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2664
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2670
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A267C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2688
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2694
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A26A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A26AC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A26B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A26C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A26D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A26DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A26E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A26F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2700
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A270C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2718
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2724
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2730
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A273C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2748
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2754
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2760
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A276C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2778
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2784
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2790
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A279C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A27A8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A27B4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A27C0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A27CC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A27D8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A27E4
+	voice_noise_alt 60, 0, 0, 0, 2, 7, 0 @ 84A27F0
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 1 @ 84A27FC
 
+	.align 2
 voicegroup189:: @ 84A2808
 	voice_keysplit_all voicegroup002 @ 84A2808
 	voice_keysplit voicegroup003, KeySplitTable1 @ 84A2814
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2820
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A282C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2820
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A282C
 	voice_directsound 60, 0, DirectSoundWaveData_sd90_classical_detuned_ep1_low, 255, 188, 128, 226 @ 84A2838
 	voice_directsound 60, 65, DirectSoundWaveData_sd90_classical_detuned_ep1_high, 128, 204, 77, 246 @ 84A2844
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2850
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A285C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2868
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2874
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2880
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A288C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2898
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A28A4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2850
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A285C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2868
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2874
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2880
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A288C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2898
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A28A4
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_tubular_bell, 255, 165, 90, 216 @ 84A28B0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A28BC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A28C8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A28BC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A28C8
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_organ2, 51, 0, 203, 127 @ 84A28D4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A28E0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A28EC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A28F8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2904
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2910
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A291C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A28E0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A28EC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A28F8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2904
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2910
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A291C
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 128, 249, 25, 127 @ 84A2928
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_nylon_str_guitar, 64, 216, 51, 224 @ 84A2934
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2940
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A294C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2958
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2964
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2970
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A297C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2988
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2994
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A29A0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2940
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A294C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2958
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2964
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2970
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A297C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2988
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2994
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A29A0
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_fretless_bass, 255, 253, 0, 188 @ 84A29AC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A29B8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A29C4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A29D0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A29DC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A29E8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A29F4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A29B8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A29C4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A29D0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A29DC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A29E8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A29F4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A3C
 	voice_keysplit voicegroup004, KeySplitTable2 @ 84A2A48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2A9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2AA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2AB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2AC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2ACC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2AD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2AE4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2AF0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2AFC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B14
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B5C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B68
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2A9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2AA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2AB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2AC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2ACC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2AD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2AE4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2AF0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2AFC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B08
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B20
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B68
 	voice_directsound 60, 0, DirectSoundWaveData_sc88pro_flute, 255, 127, 231, 127 @ 84A2B74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2B98
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2BA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2BB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2BBC
-	voice_square_1_alt 0, 2, 0, 2, 6, 3 @ 84A2BC8
-	voice_square_2_alt 3, 0, 2, 7, 2 @ 84A2BD4
-	voice_square_1_alt 0, 1, 0, 2, 6, 2 @ 84A2BE0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2BEC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2BF8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C10
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C1C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C28
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C34
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C40
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C4C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2B98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2BA4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2BB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2BBC
+	voice_square_1_alt 60, 0, 0, 2, 0, 2, 6, 3 @ 84A2BC8
+	voice_square_2_alt 60, 0, 3, 0, 2, 7, 2 @ 84A2BD4
+	voice_square_1_alt 60, 0, 0, 1, 0, 2, 6, 2 @ 84A2BE0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2BEC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2BF8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C04
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C1C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C28
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C34
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C40
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C4C
 
+	.align 2
 voicegroup190:: @ 84A2C58
-	voice_programmable_wave_alt gProgrammableWaveData_84A31EC, 0, 7, 15, 2 @ 84A2C58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2C94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2CA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2CAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2CB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2CC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2CD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2CDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2CE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2CF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D00
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D0C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D18
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D24
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D30
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D3C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D48
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D54
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D60
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D6C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D78
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D84
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D90
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2D9C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2DA8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2DB4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2DC0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2DCC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2DD8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2DE4
-	voice_noise_alt 0, 0, 2, 7, 0 @ 84A2DF0
-	voice_noise_alt 0, 0, 1, 9, 1 @ 84A2DFC
+	voice_programmable_wave_alt 60, 0, gProgrammableWaveData_84A31EC, 0, 7, 15, 2 @ 84A2C58
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2C94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2CA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2CAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2CB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2CC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2CD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2CDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2CE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2CF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D00
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D0C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D18
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D24
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D30
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D3C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D48
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D54
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D60
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D6C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D78
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D84
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D90
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2D9C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2DA8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2DB4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2DC0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2DCC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2DD8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2DE4
+	voice_noise_alt 60, 0, 0, 0, 2, 7, 0 @ 84A2DF0
+	voice_noise_alt 60, 0, 0, 0, 1, 9, 1 @ 84A2DFC
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_drum_and_percussion_kick, 255, 0, 255, 0 @ 84A2E08
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2E14
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2E14
 	voice_directsound_no_resample 64, 52, DirectSoundWaveData_sc88pro_orchestra_snare, 255, 0, 255, 242 @ 84A2E20
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2E2C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2E38
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2E44
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2E50
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2E5C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2E2C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2E38
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2E44
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2E50
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2E5C
 	voice_directsound_no_resample 60, 64, DirectSoundWaveData_sc88pro_rnd_snare, 255, 0, 255, 242 @ 84A2E68
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2E74
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2E80
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2E8C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2E98
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2E74
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2E80
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2E8C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2E98
 	voice_directsound_no_resample 33, 104, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 84A2EA4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2EB0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2EBC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2EB0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2EBC
 	voice_directsound 63, 64, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 84A2EC8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2ED4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2ED4
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88pro_tambourine, 255, 127, 77, 204 @ 84A2EE0
 	voice_directsound_no_resample 64, 14, DirectSoundWaveData_trinity_cymbal_crash, 255, 231, 0, 188 @ 84A2EEC
 	voice_directsound_no_resample 64, 89, DirectSoundWaveData_sd90_cowbell, 255, 0, 255, 242 @ 84A2EF8
 	voice_directsound_no_resample 64, 24, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 84A2F04
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2F10
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2F10
 	voice_directsound_no_resample 64, 54, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 255, 235, 0, 231 @ 84A2F1C
 	voice_directsound_no_resample 64, 54, DirectSoundWaveData_sc88pro_orchestra_cymbal_crash, 8, 0, 255, 216 @ 84A2F28
 	voice_directsound_no_resample 64, 94, DirectSoundWaveData_unused_heart_of_asia_indian_drum, 255, 0, 255, 0 @ 84A2F34
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88pro_mute_high_conga, 255, 0, 255, 0 @ 84A2F40
 	voice_directsound_no_resample 64, 34, DirectSoundWaveData_sc88pro_open_low_conga, 255, 0, 255, 0 @ 84A2F4C
 	voice_directsound_no_resample 64, 90, DirectSoundWaveData_sc88pro_open_low_conga, 255, 0, 255, 0 @ 84A2F58
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2F64
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2F70
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2F7C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2F88
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2F94
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2FA0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2FAC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2FB8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2FC4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2FD0
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2FDC
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2FE8
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A2FF4
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A3000
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A300C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2F64
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2F70
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2F7C
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2F88
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2F94
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2FA0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2FAC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2FB8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2FC4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2FD0
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2FDC
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2FE8
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A2FF4
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A3000
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A300C
 	voice_directsound_no_resample 64, 39, DirectSoundWaveData_sd90_open_triangle, 255, 242, 103, 188 @ 84A3018
 	voice_directsound_no_resample 64, 79, DirectSoundWaveData_sd90_open_triangle, 255, 242, 103, 188 @ 84A3024
 	voice_directsound_no_resample 64, 39, DirectSoundWaveData_sd90_open_triangle, 255, 165, 103, 188 @ 84A3030
 	voice_directsound_no_resample 64, 64, DirectSoundWaveData_sc88pro_jingle_bell, 255, 0, 255, 0 @ 84A303C
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A3048
-	voice_square_1 0, 2, 0, 0, 15, 0 @ 84A3054
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A3048
+	voice_square_1 60, 0, 0, 2, 0, 0, 15, 0 @ 84A3054
 	voice_directsound_no_resample 64, 104, DirectSoundWaveData_ethnic_flavours_atarigane, 255, 0, 255, 0 @ 84A3060
 	voice_directsound 63, 64, DirectSoundWaveData_sc88pro_taiko, 255, 0, 255, 0 @ 84A306C


### PR DESCRIPTION
Also explicitly align voicegroups since they weren't for some reason.

Besides that, same changes as [#1195](https://github.com/pret/pokeemerald/pull/1195) from pokeemerald.