### PR TITLE
Fix hang when releasing after adding new moves

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3195,7 +3195,7 @@ u32 GetBoxMonData(struct BoxPokemon *boxMon, s32 field, u8 *data)
             u16 *moves = (u16 *)data;
             s32 i = 0;
 
-            while (moves[i] != 355)
+            while (moves[i] != MOVES_COUNT)
             {
                 u16 move = moves[i];
                 if (substruct1->moves[0] == move


### PR DESCRIPTION
This not using a constant causes a long freeze when releasing pokemon if a new move is added