### PR TITLE
Fix Vermilion Gym Script Label Transposition Typos

### DIFF
--- a/data/maps/VermilionCity_Gym/scripts.inc
+++ b/data/maps/VermilionCity_Gym/scripts.inc
@@ -208,7 +208,7 @@ VermilionCity_Gym_EventScript_SetBeamsOn:: @ 816B8EF
 VermilionCity_Gym_EventScript_LtSurge:: @ 816B94A
 	famechecker FAMECHECKER_LTSURGE, FCPICKSTATE_COLORED, UpdatePickStateFromSpecialVar8005
 	trainerbattle_single TRAINER_LEADER_LT_SURGE, VermilionCity_Gym_Text_LtSurgeIntro, VermilionCity_Gym_Text_LtSurgeDefeat, VermilionCity_Gym_EventScript_DefeatedLtSurge, NO_MUSIC
-	goto_if_unset FLAG_GOT_TM34_FROM_SURGE, VermilionCity_Gym_EventScript_GiveTM43
+	goto_if_unset FLAG_GOT_TM34_FROM_SURGE, VermilionCity_Gym_EventScript_GiveTM34
 	msgbox VermilionCity_Gym_Text_LtSurgePostBattle
 	release
 	end
@@ -220,25 +220,25 @@ VermilionCity_Gym_EventScript_DefeatedLtSurge:: @ 816B97C
 	setflag FLAG_DEFEATED_LT_SURGE
 	setflag FLAG_BADGE03_GET
 	set_gym_trainers 3
-	goto VermilionCity_Gym_EventScript_GiveTM43
+	goto VermilionCity_Gym_EventScript_GiveTM34
 	end
 
 VermilionCity_Gym_EventScript_ShowOaksAide:: @ 816B9AB
 	clearflag FLAG_HIDE_VERMILION_CITY_OAKS_AIDE
 	return
 
-VermilionCity_Gym_EventScript_GiveTM43:: @ 816B9AF
+VermilionCity_Gym_EventScript_GiveTM34:: @ 816B9AF
 	msgbox VermilionCity_Gym_Text_ExplainThunderBadgeTakeThis
 	checkitemspace ITEM_TM34, 1
 	compare VAR_RESULT, FALSE
-	goto_if_eq VermilionCity_Gym_EventScript_NoRoomForTM43
-	giveitem_msg VermilionCity_Gym_Text_ReceivedTM43FromLtSurge, ITEM_TM34
+	goto_if_eq VermilionCity_Gym_EventScript_NoRoomForTM34
+	giveitem_msg VermilionCity_Gym_Text_ReceivedTM34FromLtSurge, ITEM_TM34
 	setflag FLAG_GOT_TM34_FROM_SURGE
 	msgbox VermilionCity_Gym_Text_ExplainTM34
 	release
 	end
 
-VermilionCity_Gym_EventScript_NoRoomForTM43:: @ 816B9F0
+VermilionCity_Gym_EventScript_NoRoomForTM34:: @ 816B9F0
 	msgbox VermilionCity_Gym_Text_MakeRoomInYourBag
 	release
 	end

--- a/data/maps/VermilionCity_Gym/text.inc
+++ b/data/maps/VermilionCity_Gym/text.inc
@@ -23,7 +23,7 @@ VermilionCity_Gym_Text_ExplainThunderBadgeTakeThis:: @ 8194CFA
     .string "You're special, kid!\n"
     .string "Take this!$"
 
-VermilionCity_Gym_Text_ReceivedTM43FromLtSurge:: @ 8194D87
+VermilionCity_Gym_Text_ReceivedTM34FromLtSurge:: @ 8194D87
     .string "{PLAYER} received TM34\n"
     .string "from LT. SURGE.$"
 


### PR DESCRIPTION
The script labels for being given TM34 from Lt. Surge are mistakenly typoed as TM43. This commit fixes this error.