### PR TITLE
Fix Typos / Use Box Constants / Name an Unknown

### DIFF
--- a/data/maps/CeladonCity_Condominiums_RoofRoom/scripts.inc
+++ b/data/maps/CeladonCity_Condominiums_RoofRoom/scripts.inc
@@ -13,15 +13,15 @@ CeladonCity_Condominiums_RoofRoom_EventScript_EeveeBall:: @ 816C46D
 	setvar VAR_TEMP_1, SPECIES_EEVEE
 	givemon SPECIES_EEVEE, 25, ITEM_NONE
 	compare VAR_RESULT, 0
-	goto_if_eq CeladonCity_Condominiums_RoofRoom_EventScript_GetEeeveeParty
+	goto_if_eq CeladonCity_Condominiums_RoofRoom_EventScript_GetEeveeParty
 	compare VAR_RESULT, 1
-	goto_if_eq CeladonCity_Condominiums_RoofRoom_EventScript_GetEeeveePC
+	goto_if_eq CeladonCity_Condominiums_RoofRoom_EventScript_GetEeveePC
 	compare VAR_RESULT, 2
 	goto_if_eq EventScript_NoMoreRoomForPokemon
 	release
 	end
 
-CeladonCity_Condominiums_RoofRoom_EventScript_GetEeeveeParty:: @ 816C4A6
+CeladonCity_Condominiums_RoofRoom_EventScript_GetEeveeParty:: @ 816C4A6
 	removeobject LOCALID_EEVEE_POKEBALL
 	playfanfare MUS_LEVEL_UP
 	message CeladonCity_Condominiums_RoofRoom_Text_ObtainedAnEevee
@@ -36,7 +36,7 @@ CeladonCity_Condominiums_RoofRoom_EventScript_GetEeeveeParty:: @ 816C4A6
 	goto CeladonCity_Condominiums_RoofRoom_EventScript_SetGotEevee
 	end
 
-CeladonCity_Condominiums_RoofRoom_EventScript_GetEeeveePC:: @ 816C4DA
+CeladonCity_Condominiums_RoofRoom_EventScript_GetEeveePC:: @ 816C4DA
 	removeobject LOCALID_EEVEE_POKEBALL
 	playfanfare MUS_LEVEL_UP
 	message CeladonCity_Condominiums_RoofRoom_Text_ObtainedAnEevee

--- a/include/global.h
+++ b/include/global.h
@@ -736,7 +736,7 @@ struct ExternalEventData
 struct ExternalEventFlags
 {
     u8 usedBoxRS:1; // Set by Pokémon Box: Ruby & Sapphire; denotes whether this save has connected to it and triggered the free False Swipe Swablu Egg giveaway.
-    u8 boxRSEggsUnlocked:2; // Set by Pokémon Box: Ruby & Sapphire; denotes the number of Eggs unlocked from deposits; 1 for ExtremeSpeed Zigzagoon (at 100 deposited), 2 for Pay Day Skitty (at 500 deposited), 3 for Surf Pichu (at 1500 deposited)
+    u8 boxRSEggsUnlocked:2; // Set by Pokémon Box: Ruby & Sapphire; denotes the number of Eggs unlocked from deposits; 1 for ExtremeSpeed Zigzagoon (at 100 deposited), 2 for Pay Day Skitty (at 500 deposited), 3 for Surf Pichu (at 1499 deposited)
     u8 padding:5;
     u8 unknownFlag1;
     u8 receivedGCNJirachi; // Both the US Colosseum Bonus Disc and PAL/AUS Pokémon Channel use this field. One cannot receive a WISHMKR Jirachi and CHANNEL Jirachi with the same savefile.

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -1125,7 +1125,7 @@ void StopPlayerAvatar(void)
     }
 }
 
-static const u8 sPlayerAvatarGfxIds[][2] = {
+static const u8 sPlayerAvatarGfxIds[][GENDER_COUNT] = {
     {OBJ_EVENT_GFX_RED_NORMAL,    OBJ_EVENT_GFX_GREEN_NORMAL},
     {OBJ_EVENT_GFX_RED_BIKE,      OBJ_EVENT_GFX_GREEN_BIKE},
     {OBJ_EVENT_GFX_RED_SURF,      OBJ_EVENT_GFX_GREEN_SURF},
@@ -1230,15 +1230,13 @@ void SetPlayerAvatarStateMask(u8 flags)
     gPlayerAvatar.flags |= flags;
 }
 
-static const u8 gUnknown_835B882[][3][2] = {
-    // Male
-    {
+static const u8 sPlayerAvatarGfxToStateFlag[][3][GENDER_COUNT] = {
+    [MALE] = {
         {OBJ_EVENT_GFX_RED_NORMAL, PLAYER_AVATAR_FLAG_ON_FOOT},
         {OBJ_EVENT_GFX_RED_BIKE,   PLAYER_AVATAR_FLAG_MACH_BIKE},
         {OBJ_EVENT_GFX_RED_SURF,   PLAYER_AVATAR_FLAG_SURFING},
     },
-    // Female
-    {
+    [FEMALE] = {
         {OBJ_EVENT_GFX_GREEN_NORMAL, PLAYER_AVATAR_FLAG_ON_FOOT},
         {OBJ_EVENT_GFX_GREEN_BIKE,   PLAYER_AVATAR_FLAG_MACH_BIKE},
         {OBJ_EVENT_GFX_GREEN_SURF,   PLAYER_AVATAR_FLAG_SURFING},
@@ -1249,10 +1247,10 @@ u8 GetPlayerAvatarStateTransitionByGraphicsId(u8 graphicsId, u8 gender)
 {
     u8 i;
 
-    for (i = 0; i < NELEMS(*gUnknown_835B882); i++)
+    for (i = 0; i < NELEMS(*sPlayerAvatarGfxToStateFlag); i++)
     {
-        if (gUnknown_835B882[gender][i][0] == graphicsId)
-            return gUnknown_835B882[gender][i][1];
+        if (sPlayerAvatarGfxToStateFlag[gender][i][0] == graphicsId)
+            return sPlayerAvatarGfxToStateFlag[gender][i][1];
     }
     return 1;
 }
@@ -1262,10 +1260,10 @@ u8 GetPlayerAvatarGraphicsIdByCurrentState(void)
     u8 i;
     u8 r5 = gPlayerAvatar.flags;
 
-    for (i = 0; i < NELEMS(*gUnknown_835B882); i++)
+    for (i = 0; i < NELEMS(*sPlayerAvatarGfxToStateFlag); i++)
     {
-        if (gUnknown_835B882[gPlayerAvatar.gender][i][1] & r5)
-            return gUnknown_835B882[gPlayerAvatar.gender][i][0];
+        if (sPlayerAvatarGfxToStateFlag[gPlayerAvatar.gender][i][1] & r5)
+            return sPlayerAvatarGfxToStateFlag[gPlayerAvatar.gender][i][0];
     }
     return 0;
 }

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3799,8 +3799,8 @@ static bool8 IsPokemonStorageFull(void)
 {
     s32 i, j;
 
-    for (i = 0; i < 14; i++)
-        for (j = 0; j < 30; j++)
+    for (i = 0; i < TOTAL_BOXES_COUNT; i++)
+        for (j = 0; j < IN_BOX_COUNT; j++)
             if (GetBoxMonDataAt(i, j, MON_DATA_SPECIES) == SPECIES_NONE)
                 return FALSE;
 


### PR DESCRIPTION
The Celadon City scripts that give Eevee misspelled it as Eeevee. Fixed.

The comment explaining `boxRSEggsUnlocked` in the `ExternalEventFlags` struct had an incorrect deposit requirement listed and was fixed.

Also, replaced the literals with the `TOTAL_BOXES_COUNT` and `IN_BOX_COUNT` constants in `pokemon.c`'s `IsPokemonStorageFull` function. Thanks hjk321 for pointing that out.

`gUnknown_835B882` has been cleaned up and renamed to `sPlayerAvatarGfxToStateFlag` to match pokeemerald. Thanks Spherical Ice for pointing it out.