### PR TITLE
Fix Trade Nonmatchings (Thanks to Shoomer/RadicalDweamer)

### DIFF
--- a/src/trade.c
+++ b/src/trade.c
@@ -674,7 +674,7 @@ static const u8 gUnknown_8262055[][2] = {
 static void InitTradeMenuResources(void)
 {
     int i;
-    static vu16 dummy;
+    static u16 dummy;
 
     ResetSpriteData();
     FreeAllSpritePalettes();
@@ -723,11 +723,6 @@ static void CB2_ReturnFromLinkTrade2(void)
     u8 id;
     s32 width;
     u32 xPos;
-#ifndef NONMATCHING
-    register u32 r0 asm("r0");
-#else
-    u32 r0;
-#endif
     u8 *name;
 
     switch (gMain.state)
@@ -895,7 +890,8 @@ static void CB2_ReturnFromLinkTrade2(void)
             gMain.state++;
         break;
     case 12:
-        width = GetStringWidth(1, gSaveBlock2Ptr->playerName, 0);
+        name = gSaveBlock2Ptr->playerName;
+        width = GetStringWidth(1, name, 0);
         xPos = (56 - width) / 2;
         for (i = 0; i < 3; i++)
         {
@@ -904,9 +900,8 @@ static void CB2_ReturnFromLinkTrade2(void)
             CreateSprite(&temp, xPos + sTradeUnknownSpriteCoords[LANGUAGE_ENGLISH - 1][0] + (i * 32), sTradeUnknownSpriteCoords[LANGUAGE_ENGLISH - 1][1], 1);
         }
         id = GetMultiplayerId();
-        r0 = (id ^ 1) * sizeof(*gLinkPlayers);
-        name = gLinkPlayers->name;
-        width = GetStringWidth(1, name + r0, 0);
+        name = gLinkPlayers[id ^ 1].name;
+        width = GetStringWidth(1, name, 0);
         xPos = (56 - width) / 2;
         for (i = 0; i < 3; i++)
         {
@@ -999,11 +994,6 @@ void CB2_ReturnToTradeMenuFromSummary(void)
     u8 id;
     s32 width;
     u32 xPos;
-#ifndef NONMATCHING
-    register u32 r0 asm("r0");
-#else
-    u32 r0;
-#endif
     u8 *name;
 
     switch (gMain.state)
@@ -1095,7 +1085,8 @@ void CB2_ReturnToTradeMenuFromSummary(void)
         }
         break;
     case 12:
-        width = GetStringWidth(1, gSaveBlock2Ptr->playerName, 0);
+        name = gSaveBlock2Ptr->playerName;
+        width = GetStringWidth(1, name, 0);
         xPos = (56 - width) / 2;
         for (i = 0; i < 3; i++)
         {
@@ -1104,9 +1095,8 @@ void CB2_ReturnToTradeMenuFromSummary(void)
             CreateSprite(&temp, xPos + sTradeUnknownSpriteCoords[LANGUAGE_ENGLISH - 1][0] + (i * 32), sTradeUnknownSpriteCoords[LANGUAGE_ENGLISH - 1][1], 1);
         }
         id = GetMultiplayerId();
-        r0 = (id ^ 1) * sizeof(*gLinkPlayers);
-        name = gLinkPlayers->name;
-        width = GetStringWidth(1, name + r0, 0);
+        name = gLinkPlayers[id ^ 1].name;
+        width = GetStringWidth(1, name, 0);
         xPos = (56 - width) / 2;
         for (i = 0; i < 3; i++)
         {


### PR DESCRIPTION
Taken from [this](https://gitlab.com/RadicalDweamer/pokefirered/-/commit/c1293f2245e049bd2c8c69dead4031fed89f4c77) commit by shoomer/RadicalDweamer and edited to have only necessary changes.

Change to the dummy variable is not required for matching, but it doesn't need to be volatile to match, so it seems like a good idea to let the (modern) compiler optimize it out.