### PR TITLE
Sync LinkPlayer Struct with pokeemerald

### DIFF
--- a/include/link.h
+++ b/include/link.h
@@ -127,7 +127,10 @@ struct LinkPlayer
     /* 0x00 */ u16 version;
     /* 0x02 */ u16 lp_field_2;
     /* 0x04 */ u32 trainerId;
-    /* 0x08 */ u8 name[11];
+    /* 0x08 */ u8 name[PLAYER_NAME_LENGTH + 1];
+    /* 0x10 */ u8 progressFlags; // (& 0x0F) is hasNationalDex, (& 0xF0) is hasClearedGame
+    /* 0x11 */ u8 neverRead;
+    /* 0x12 */ u8 progressFlagsCopy;
     /* 0x13 */ u8 gender;
     /* 0x14 */ u32 linkType;
     /* 0x18 */ u16 id; // battle bank in battles
@@ -277,7 +280,7 @@ void CreateWirelessStatusIndicatorSprite(u8, u8);
 void sub_8009FE8(void);
 void ClearLinkCallback_2(void);
 void Rfu_SetLinkStandbyCallback(void);
-void IntlConvertLinkPlayerName(struct LinkPlayer * linkPlayer);
+void ConvertLinkPlayerName(struct LinkPlayer * linkPlayer);
 bool8 IsWirelessAdapterConnected(void);
 bool8 Link_PrepareCmd0xCCCC_Rfu0xA100(u8 blockRequestType);
 void LinkVSync(void);

--- a/src/cable_club.c
+++ b/src/cable_club.c
@@ -659,7 +659,7 @@ static void Task_StartWirelessCableClubBattle(u8 taskId)
             for (i = 0; i < GetLinkPlayerCount(); i++)
             {
                 gLinkPlayers[i] = *(struct LinkPlayer *)gBlockRecvBuffer[i];
-                IntlConvertLinkPlayerName(&gLinkPlayers[i]);
+                ConvertLinkPlayerName(&gLinkPlayers[i]);
                 ResetBlockReceivedFlag(i);
             }
             data[0] = 4;

--- a/src/link.c
+++ b/src/link.c
@@ -321,10 +321,10 @@ static void InitLocalLinkPlayer(void)
     gLocalLinkPlayer.language = gGameLanguage;
     gLocalLinkPlayer.version = gGameVersion + 0x4000;
     gLocalLinkPlayer.lp_field_2 = 0x8000;
-    gLocalLinkPlayer.name[8] = IsNationalPokedexEnabled();
+    gLocalLinkPlayer.progressFlags = IsNationalPokedexEnabled();
     if (FlagGet(FLAG_SYS_CAN_LINK_WITH_RS))
     {
-        gLocalLinkPlayer.name[8] |= 0x10;
+        gLocalLinkPlayer.progressFlags |= 0x10;
     }
 }
 
@@ -602,11 +602,11 @@ void ProcessRecvCmds(u8 unused)
                     *linkPlayer = block->linkPlayer;
                     if ((linkPlayer->version & 0xFF) == VERSION_RUBY || (linkPlayer->version & 0xFF) == VERSION_SAPPHIRE)
                     {
-                        linkPlayer->name[10] = 0;
-                        linkPlayer->name[9] = 0;
-                        linkPlayer->name[8] = 0;
+                        linkPlayer->progressFlagsCopy = 0;
+                        linkPlayer->neverRead = 0;
+                        linkPlayer->progressFlags = 0;
                     }
-                    IntlConvertLinkPlayerName(linkPlayer);
+                    ConvertLinkPlayerName(linkPlayer);
                     if (strcmp(block->magic1, sASCIIGameFreakInc) != 0
                         || strcmp(block->magic2, sASCIIGameFreakInc) != 0)
                     {
@@ -1640,7 +1640,7 @@ void LinkPlayerFromBlock(u32 who)
     block = (struct LinkPlayerBlock *)gBlockRecvBuffer[who_];
     player = &gLinkPlayers[who_];
     *player = block->linkPlayer;
-    IntlConvertLinkPlayerName(player);
+    ConvertLinkPlayerName(player);
     if (strcmp(block->magic1, sASCIIGameFreakInc) != 0 || strcmp(block->magic2, sASCIIGameFreakInc) != 0)
     {
         SetMainCallback2(CB2_LinkError);
@@ -1718,9 +1718,9 @@ bool32 LinkRecvQueueLengthMoreThan2(void)
     return FALSE;
 }
 
-void IntlConvertLinkPlayerName(struct LinkPlayer * player)
+void ConvertLinkPlayerName(struct LinkPlayer * player)
 {
-    player->name[10] = player->name[8];
+    player->progressFlagsCopy = player->progressFlags; // ? Perhaps relocating for a longer name field
     ConvertInternationalString(player->name, player->language);
 }
 

--- a/src/link_rfu_2.c
+++ b/src/link_rfu_2.c
@@ -1769,7 +1769,7 @@ static void ReceiveRfuLinkPlayers(const struct SioInfo *chunk)
     for (i = 0; i < MAX_RFU_PLAYERS; i++)
     {
         gLinkPlayers[i] = chunk->linkPlayers[i];
-        IntlConvertLinkPlayerName(gLinkPlayers + i);
+        ConvertLinkPlayerName(gLinkPlayers + i);
     }
 }
 
@@ -1814,7 +1814,7 @@ static void Task_ExchangeLinkPlayers(u8 taskId)
             ResetBlockReceivedFlag(r4);
             r2 = (struct LinkPlayerBlock *)gBlockRecvBuffer[r4];
             gLinkPlayers[r4] = r2->linkPlayer;
-            IntlConvertLinkPlayerName(gLinkPlayers + r4);
+            ConvertLinkPlayerName(gLinkPlayers + r4);
             gTasks[taskId].data[0]++;
         }
         break;

--- a/src/trade.c
+++ b/src/trade.c
@@ -2623,7 +2623,7 @@ static u32 TestWhetherSelectedMonCanBeTraded(struct Pokemon * party, int partyCo
     if ((player->version & 0xFF) != VERSION_RUBY &&
         (player->version & 0xFF) != VERSION_SAPPHIRE)
     {
-        if ((player->name[10] & 0xF) == 0)
+        if ((player->progressFlagsCopy & 0xF) == 0)
         {
             if (species2[cursorPos] == SPECIES_EGG)
             {
@@ -2697,11 +2697,11 @@ s32 Trade_CalcLinkPlayerCompatibilityParam(void)
 
         if (val > 0)
         {
-            if (gLinkPlayers[GetMultiplayerId()].name[10] & 0xF0)
+            if (gLinkPlayers[GetMultiplayerId()].progressFlagsCopy & 0xF0)
             {
                 if (val == 2)
                 {
-                    if (gLinkPlayers[GetMultiplayerId() ^ 1].name[10] & 0xF0)
+                    if (gLinkPlayers[GetMultiplayerId() ^ 1].progressFlagsCopy & 0xF0)
                     {
                         return 0;
                     }


### PR DESCRIPTION
In pokefirered, the `LinkPlayer` struct used an 11-byte name field and puts extra link-related info in the last three bytes. pokeemerald separates these last three bytes into their own fields. This commit replicates how pokeemerald handles those fields.

Also renamed `IntlConvertLinkPlayerName` to pokeemerald's `ConvertLinkPlayerName` because I was there and noticed it.