### PR TITLE
Fix Magic Number in party_menu.c

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -839,7 +839,7 @@ static bool8 DisplayPartyPokemonDataForMoveTutorOrEvolutionItem(u8 slot)
     if (gPartyMenu.action == PARTY_ACTION_MOVE_TUTOR)
     {
         gSpecialVar_Result = FALSE;
-        if (gSpecialVar_0x8005 > 14)
+        if (gSpecialVar_0x8005 >= TUTOR_MOVE_COUNT)
             return FALSE;
         DisplayPartyPokemonDataToTeachMove(slot, 0, gSpecialVar_0x8005);
     }


### PR DESCRIPTION
`DisplayPartyPokemonDataForMoveTutorOrEvolutionItem` in `party_menu.c` had a magic number that was missed. This commit fixes it.