### PR TITLE
Makefile CDs From Midi Folder Properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ include songs.mk
 sound/direct_sound_samples/cry_%.bin: sound/direct_sound_samples/cry_%.aif ; $(AIF) $< $@ --compress
 sound/%.bin: sound/%.aif ; $(AIF) $< $@
 sound/songs/%.s: sound/songs/%.mid
-	cd $(@D) && ../../$(MID) $(<F)
+	cd $(@D) && ../../../$(MID) $(<F)
 
 ifeq ($(MODERN),0)
 $(C_BUILDDIR)/agb_flash.o: CFLAGS := -O -mthumb-interwork


### PR DESCRIPTION
Currently, the Makefile does not move up the correct number of directories from the midi folder to access the mid2agb tool. This causes any attempt at compiling an edited midi to fail.

Why this took so long to be discovered, the world may never know.