### PR TITLE
Document fields in oak_speech

### DIFF
--- a/src/oak_speech.c
+++ b/src/oak_speech.c
@@ -1751,12 +1751,14 @@ static void DestroyOaksSpeechTrainerPic(void)
     CopyBgTilemapBufferToVram(2);
 }
 
+#define tParentTaskId data[0]
+
 static void Task_SlowFadeIn(u8 taskId)
 {
     u8 i = 0;
-    if (gTasks[taskId].tTrainerPicPosX == 0)
+    if (gTasks[taskId].data[1] == 0)
     {
-        gTasks[gTasks[taskId].data[0]].tTrainerPicFadeState = 1;
+        gTasks[gTasks[taskId].tParentTaskId].tTrainerPicFadeState = 1;
         DestroyTask(taskId);
         for (i = 0; i < 3; i++)
         {
@@ -1770,16 +1772,16 @@ static void Task_SlowFadeIn(u8 taskId)
         else
         {
             gTasks[taskId].data[4] = gTasks[taskId].data[3];
-            gTasks[taskId].tTrainerPicPosX--;
-            gTasks[taskId].tTrainerPicFadeState++;
-            if (gTasks[taskId].tTrainerPicPosX == 8)
+            gTasks[taskId].data[1]--;
+            gTasks[taskId].data[2]++;
+            if (gTasks[taskId].data[1] == 8)
             {
                 for (i = 0; i < 3; i++)
                 {
                     gSprites[gTasks[taskId].data[7 + i]].invisible ^= TRUE;
                 }
             }
-            SetGpuReg(REG_OFFSET_BLDALPHA, (gTasks[taskId].tTrainerPicFadeState * 256) + gTasks[taskId].tTrainerPicPosX);
+            SetGpuReg(REG_OFFSET_BLDALPHA, (gTasks[taskId].data[2] * 256) + gTasks[taskId].data[1]);
         }
     }
 }
@@ -1794,9 +1796,9 @@ static void CreateFadeInTask(u8 taskId, u8 state)
     SetGpuReg(REG_OFFSET_BLDY, 0);
     gTasks[taskId].tTrainerPicFadeState = 0;
     taskId2 = CreateTask(Task_SlowFadeIn, 0);
-    gTasks[taskId2].data[0] = taskId;
-    gTasks[taskId2].tTrainerPicPosX = 16;
-    gTasks[taskId2].tTrainerPicFadeState = 0;
+    gTasks[taskId2].tParentTaskId = taskId;
+    gTasks[taskId2].data[1] = 16;
+    gTasks[taskId2].data[2] = 0;
     gTasks[taskId2].data[3] = state;
     gTasks[taskId2].data[4] = state;
     for (i = 0; i < 3; i++)
@@ -1809,11 +1811,11 @@ static void Task_SlowFadeOut(u8 taskId)
 {
     u8 i = 0;
 
-    if (gTasks[taskId].tTrainerPicPosX == 16)
+    if (gTasks[taskId].data[1] == 16)
     {
         if (!gPaletteFade.active)
         {
-            gTasks[gTasks[taskId].data[0]].tTrainerPicFadeState = 1;
+            gTasks[gTasks[taskId].tParentTaskId].tTrainerPicFadeState = 1;
             DestroyTask(taskId);
         }
     }
@@ -1824,8 +1826,8 @@ static void Task_SlowFadeOut(u8 taskId)
         else
         {
             gTasks[taskId].data[4] = gTasks[taskId].data[3];
-            gTasks[taskId].tTrainerPicPosX += 2;
-            gTasks[taskId].tTrainerPicFadeState -= 2;
+            gTasks[taskId].data[1] += 2;
+            gTasks[taskId].data[2] -= 2;
             if (gTasks[taskId].tTrainerPicPosX == 8)
             {
                 for (i = 0; i < 3; i++)
@@ -1833,7 +1835,7 @@ static void Task_SlowFadeOut(u8 taskId)
                     gSprites[gTasks[taskId].data[7 + i]].invisible ^= TRUE;
                 }
             }
-            SetGpuReg(REG_OFFSET_BLDALPHA, (gTasks[taskId].tTrainerPicFadeState * 256) + gTasks[taskId].tTrainerPicPosX);
+            SetGpuReg(REG_OFFSET_BLDALPHA, (gTasks[taskId].data[2] * 256) + gTasks[taskId].data[1]);
         }
     }
 }
@@ -1848,9 +1850,9 @@ static void CreateFadeOutTask(u8 taskId, u8 state)
     SetGpuReg(REG_OFFSET_BLDY, 0);
     gTasks[taskId].tTrainerPicFadeState = 0;
     taskId2 = CreateTask(Task_SlowFadeOut, 0);
-    gTasks[taskId2].data[0] = taskId;
-    gTasks[taskId2].tTrainerPicPosX = 0;
-    gTasks[taskId2].tTrainerPicFadeState = 16;
+    gTasks[taskId2].tParentTaskId = taskId;
+    gTasks[taskId2].data[1] = 0;
+    gTasks[taskId2].data[2] = 16;
     gTasks[taskId2].data[3] = state;
     gTasks[taskId2].data[4] = state;
     for (i = 0; i < 3; i++)

--- a/src/oak_speech.c
+++ b/src/oak_speech.c
@@ -1828,7 +1828,7 @@ static void Task_SlowFadeOut(u8 taskId)
             gTasks[taskId].data[4] = gTasks[taskId].data[3];
             gTasks[taskId].data[1] += 2;
             gTasks[taskId].data[2] -= 2;
-            if (gTasks[taskId].tTrainerPicPosX == 8)
+            if (gTasks[taskId].data[1] == 8)
             {
                 for (i = 0; i < 3; i++)
                 {

--- a/src/oak_speech.c
+++ b/src/oak_speech.c
@@ -1446,8 +1446,8 @@ static void Task_OakSpeech38_1(u8 taskId)
     u8 taskId2 = CreateTask(Task_OakSpeech38_sub1, 1);
     s16 * data = gTasks[taskId2].data;
     data[0] = 0;
-    tTrainerPicPosX = 0;
-    tTrainerPicFadeState = 0;
+    data[1] = 0;
+    data[2] = 0;
     data[15] = 0;
     BeginNormalPaletteFade(0xFFFF0FCF, 4, 0, 16, RGB_BLACK);
 }
@@ -1457,14 +1457,14 @@ static void Task_OakSpeech38_sub1(u8 taskId)
     s16 * data = gTasks[taskId].data;
     if (!gPaletteFade.active)
     {
-        if (tTrainerPicPosX != 0)
+        if (data[1] != 0)
         {
             DestroyTask(taskId);
             DestroyLinkedPikaOrGrassPlatformSprites(taskId, 1);
         }
         else
         {
-            tTrainerPicPosX++;
+            data[1]++;
             BeginNormalPaletteFade(0x0000F000, 0, 0, 16, RGB_BLACK);
         }
     }
@@ -1475,8 +1475,8 @@ static void Task_OakSpeech38_2(u8 taskId)
     u8 taskId2 = CreateTask(Task_OakSpeech38_sub2, 2);
     s16 * data = gTasks[taskId2].data;
     data[0] = 8;
-    tTrainerPicPosX = 0;
-    tTrainerPicFadeState = 8;
+    data[1] = 0;
+    data[2] = 8;
     data[14] = 0;
     data[15] = 0;
 }
@@ -1490,12 +1490,12 @@ static void Task_OakSpeech38_sub2(u8 taskId)
         data[0]--;
     else
     {
-        if (tTrainerPicPosX <= 0 && tTrainerPicFadeState != 0)
-            tTrainerPicFadeState--;
+        if (data[1] <= 0 && data[2] != 0)
+            data[2]--;
         BlendPalette(0x40, 0x20, data[14], RGB_WHITE);
         data[14]++;
-        tTrainerPicPosX--;
-        data[0] = tTrainerPicFadeState;
+        data[1]--;
+        data[0] = data[2];
         if (data[14] > 14)
         {
             for (i = 0; i < 32; i++)

--- a/src/oak_speech.c
+++ b/src/oak_speech.c
@@ -465,10 +465,10 @@ static const u8 *const sRivalNameChoices[] = {
 
 enum
 {
-    MALE_PLAYER_ID,
-    FEMALE_PLAYER_ID,
-    RIVAL_ID,
-    OAK_ID
+    MALE_PLAYER_PIC,
+    FEMALE_PLAYER_PIC,
+    RIVAL_PIC,
+    OAK_PIC
 };
 
 static void VBlankCB_NewGameOaksSpeech(void)
@@ -891,7 +891,7 @@ static void Task_OakSpeech9(u8 taskId)
         CopyToBgTilemapBuffer(1, sOakSpeech_BackgroundTilemap, 0, 0);
         CopyBgTilemapBufferToVram(1);
         CreateNidoranFSprite(taskId);
-        LoadOaksSpeechTrainerPic(OAK_ID, 0);
+        LoadOaksSpeechTrainerPic(OAK_PIC, 0);
         CreatePikaOrGrassPlatformSpriteAndLinkToCurrentTask(taskId, 1);
         PlayBGM(MUS_ROUTE24);
         BeginNormalPaletteFade(0xFFFFFFFF, 5, 16, 0, RGB_BLACK);
@@ -1121,9 +1121,9 @@ static void Task_OakSpeech21(u8 taskId)
 static void Task_OakSpeech22(u8 taskId)
 {
     if (gSaveBlock2Ptr->playerGender == MALE)
-        LoadOaksSpeechTrainerPic(MALE_PLAYER_ID, 0);
+        LoadOaksSpeechTrainerPic(MALE_PLAYER_PIC, 0);
     else
-        LoadOaksSpeechTrainerPic(FEMALE_PLAYER_ID, 0);
+        LoadOaksSpeechTrainerPic(FEMALE_PLAYER_PIC, 0);
     CreateFadeOutTask(taskId, 2);
     gTasks[taskId].data[3] = 32;
     gTasks[taskId].func = Task_OakSpeech23;
@@ -1331,7 +1331,7 @@ static void Task_OakSpeech32(u8 taskId)
     ChangeBgX(2, 0, 0);
     gTasks[taskId].tTrainerPicPosX = 0;
     gSpriteCoordOffsetX = 0;
-    LoadOaksSpeechTrainerPic(RIVAL_ID, 0);
+    LoadOaksSpeechTrainerPic(RIVAL_PIC, 0);
     CreateFadeOutTask(taskId, 2);
     gTasks[taskId].func = Task_OakSpeech34;
 }
@@ -1360,9 +1360,9 @@ static void Task_OakSpeech33(u8 taskId)
         else
         {
             if (gSaveBlock2Ptr->playerGender == MALE)
-                LoadOaksSpeechTrainerPic(MALE_PLAYER_ID, 0);
+                LoadOaksSpeechTrainerPic(MALE_PLAYER_PIC, 0);
             else
-                LoadOaksSpeechTrainerPic(FEMALE_PLAYER_ID, 0);
+                LoadOaksSpeechTrainerPic(FEMALE_PLAYER_PIC, 0);
             gTasks[taskId].tTrainerPicPosX = 0;
             gSpriteCoordOffsetX = 0;
             ChangeBgX(2, 0, 0);
@@ -1597,12 +1597,12 @@ static void CB2_ReturnFromNamingScreen(void)
         if (sOakSpeechResources->hasPlayerBeenNamed == FALSE)
         {
             if (gSaveBlock2Ptr->playerGender == MALE)
-                LoadOaksSpeechTrainerPic(MALE_PLAYER_ID, 0);
+                LoadOaksSpeechTrainerPic(MALE_PLAYER_PIC, 0);
             else
-                LoadOaksSpeechTrainerPic(FEMALE_PLAYER_ID, 0);
+                LoadOaksSpeechTrainerPic(FEMALE_PLAYER_PIC, 0);
         }
         else
-            LoadOaksSpeechTrainerPic(RIVAL_ID, 0);
+            LoadOaksSpeechTrainerPic(RIVAL_PIC, 0);
         gTasks[taskId].tTrainerPicPosX = -60;
         gSpriteCoordOffsetX += 60;
         ChangeBgX(2, -0x3C00, 0);
@@ -1715,19 +1715,19 @@ static void LoadOaksSpeechTrainerPic(u16 whichPic, u16 tileOffset)
 
     switch (whichPic)
     {
-    case MALE_PLAYER_ID:
+    case MALE_PLAYER_PIC:
         LoadPalette(sOakSpeechGfx_RedPal, 0x40, 0x40);
         LZ77UnCompVram(sOakSpeechGfx_RedPic, (void *)0x06000600 + tileOffset);
         break;
-    case FEMALE_PLAYER_ID:
+    case FEMALE_PLAYER_PIC:
         LoadPalette(sOakSpeechGfx_LeafPal, 0x40, 0x40);
         LZ77UnCompVram(sOakSpeechGfx_LeafPic, (void *)0x06000600 + tileOffset);
         break;
-    case RIVAL_ID:
+    case RIVAL_PIC:
         LoadPalette(sOakSpeechGfx_RivalPal, 0x60, 0x40);
         LZ77UnCompVram(sOakSpeechGfx_RivalPic, (void *)0x06000600 + tileOffset);
         break;
-    case OAK_ID:
+    case OAK_PIC:
         LoadPalette(sOakSpeechGfx_OakPal, 0x60, 0x40);
         LZ77UnCompVram(sOakSpeechGfx_OakPic, (void *)0x06000600 + tileOffset);
         break;


### PR DESCRIPTION
`unk_0010` is only ever used as a boolean check for whether the player has been named or not, to differentiate the state of the intro naming tasks (whether you're naming the player or the rival), so suggest renaming to `hasPlayerBeenNamed`.

`data[1]` stores the horizontal offset of BG2 (where the trainer pics are rendered), so suggest #defining it as `tTrainerPicPosX`.
`data[2]` stores the state of the fade in/out (blending) of BG2 (value 0 when no fading is active), so suggest #defining it as `tTrainerPicFadeState`.

Since the trainer pics (Male/female player, Rival and Oak) in BG2 are always loaded with the same IDs, also thinks this reads cleaner as an enum.