### PR TITLE
Fix Magic Number in sub_8064544 in event_object_movement.c

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -5301,7 +5301,7 @@ static void sub_8064544(struct ObjectEvent *objectEvent, struct Sprite *sprite)
     if (gMovementActionFuncs[objectEvent->movementActionId][sprite->data[2]](objectEvent, sprite))
     {
         objectEvent->heldMovementFinished = TRUE;
-        if (objectEvent->graphicsId == 0x61)
+        if (objectEvent->graphicsId == OBJ_EVENT_GFX_PUSHABLE_BOULDER)
             HandleBoulderFallThroughHole(objectEvent);
     }
 }


### PR DESCRIPTION
`sub_8064544()` has something to do with handling boulder puzzles and used a magic number instead of `OBJ_EVENT_GFX_PUSHABLE_BOULDER` while checking the object's `graphicsId`. This has been fixed.