### PR TITLE
Replaced undefined BUGFIX_SETMONIVS with good ol' BUGFIX

### DIFF
--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -3612,7 +3612,7 @@ void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg)
         break;
     case MON_DATA_IVS:
     {
-#ifdef BUGFIX_SETMONIVS
+#ifdef BUGFIX
         u32 ivs = data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
 #else
         u32 ivs = *data; // Bug: Only the HP IV and the lower 3 bits of the Attack IV are read. The rest become 0.


### PR DESCRIPTION
## Description
Someone added a bugfix preproc directive without ever defining it anywhere, leaving that up to the user, instead of using the already defined and already used `BUGFIX` constant.
This PR "solves" that.

**EDIT**: Lmao, it was Revo, 4 years ago, well before `BUGFIX` was established. Still, I guess this PR still holds some value in keeping the `BUGFIX`es consistent in how they're handled in this project.

## Discord Contact
Lunos#4026