### PR TITLE
Add *.rl to make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ compare:
 mostlyclean: tidy
 	$(RM) sound/direct_sound_samples/*.bin
 	$(RM) $(SONG_OBJS) $(MID_SUBDIR)/*.s
-	find . \( -iname '*.1bpp' -o -iname '*.4bpp' -o -iname '*.8bpp' -o -iname '*.gbapal' -o -iname '*.lz' -o -iname '*.latfont' -o -iname '*.hwjpnfont' -o -iname '*.fwjpnfont' \) -exec rm {} +
+	find . \( -iname '*.1bpp' -o -iname '*.4bpp' -o -iname '*.8bpp' -o -iname '*.gbapal' -o -iname '*.lz' -o -iname '*.rl' -o -iname '*.latfont' -o -iname '*.hwjpnfont' -o -iname '*.fwjpnfont' \) -exec rm {} +
 	$(RM) $(DATA_ASM_SUBDIR)/layouts/layouts.inc $(DATA_ASM_SUBDIR)/layouts/layouts_table.inc
 	$(RM) $(DATA_ASM_SUBDIR)/maps/connections.inc $(DATA_ASM_SUBDIR)/maps/events.inc $(DATA_ASM_SUBDIR)/maps/groups.inc $(DATA_ASM_SUBDIR)/maps/headers.inc
 	find $(DATA_ASM_SUBDIR)/maps \( -iname 'connections.inc' -o -iname 'events.inc' -o -iname 'header.inc' \) -exec rm {} +


### PR DESCRIPTION
ExpoSeed noticed in pokeemerald that *.rl (RLE compressed) files were not being cleaned with the rest of the work files in `make clean`. This PR aims to resolve this minor issue.
Companion PRs at https://github.com/pret/pokeemerald/pull/1225 and https://github.com/pret/pokeruby/pull/845