### PR TITLE
Sync debug print functions

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -13,6 +13,28 @@
 // Fire Red likely forgot to define NDEBUG/NOAGBPRN before release, leading
 // to the inclusion of asserts in the retail ROM.
 
+#ifndef NDEBUG
+#define PRETTY_PRINT_OFF (0)
+#define PRETTY_PRINT_MINI_PRINTF (1)
+#define PRETTY_PRINT_LIBC (2)
+
+#define LOG_HANDLER_AGB_PRINT (0)
+#define LOG_HANDLER_NOCASH_PRINT (1)
+#define LOG_HANDLER_MGBA_PRINT (2)
+
+// Use this switch to choose a handler for pretty printing.
+// NOTE: mini_printf supports a custom pretty printing formatter to display preproc encoded strings. (%S)
+//       some libc distributions (especially dkp arm-libc) will fail to link pretty printing.
+#define PRETTY_PRINT_HANDLER (PRETTY_PRINT_OFF)
+
+// Use this switch to choose a handler for printf output.
+// NOTE: These will only work on the respective emulators and should not be used in a productive environment.
+//       Some emulators or real hardware might (and is allowed to) crash if they are used.
+//       AGB_PRINT is supported on respective debug units.
+
+#define LOG_HANDLER (LOG_HANDLER_AGB_PRINT)
+#endif // NDEBUG
+
 // Define the game version for use elsewhere
 #if defined(FIRERED)
 #define GAME_VERSION VERSION_FIRE_RED

--- a/include/gba/isagbprint.h
+++ b/include/gba/isagbprint.h
@@ -1,55 +1,69 @@
 #ifndef GUARD_GBA_ISAGBPRINT_H
 #define GUARD_GBA_ISAGBPRINT_H
 
+#include "gba/types.h"
+
+#define MGBA_LOG_FATAL  (0)
+#define MGBA_LOG_ERROR  (1)
+#define MGBA_LOG_WARN   (2)
+#define MGBA_LOG_INFO   (3)
+#define MGBA_LOG_DEBUG  (4)
+
 #ifdef NDEBUG
+#define DebugPrintf(pBuf, ...)
+#define DebugPrintfLevel(level, pBuf, ...)
+#define MgbaOpen()
+#define MgbaClose()
 #define AGBPrintInit()
-#define AGBPutc(cChr)
-#define AGBPrint(pBuf)
-#define	AGBPrintf(pBuf, ...)
-#define AGBPrintFlush1Block()
-#define AGBPrintFlush()
-#define AGBAssert(pFile, nLine, pExpression, nStopProgram)
+#define DebugAssert(pFile, nLine, pExpression, nStopProgram)
 #else
-void AGBPrintInit(void);
-void AGBPutc(const char cChr);
-void AGBPrint(const char *pBuf);
+
+bool32 MgbaOpen(void);
+void MgbaClose(void);
+void MgbaPrintf(s32 level, const char *pBuf, ...);
+void MgbaAssert(const char *pFile, s32 nLine, const char *pExpression, bool32 nStopProgram);
+void NoCashGBAPrintf(const char *pBuf, ...);
+void NoCashGBAAssert(const char *pFile, s32 nLine, const char *pExpression, bool32 nStopProgram);
 void AGBPrintf(const char *pBuf, ...);
-void AGBPrintFlush1Block(void);
-void AGBPrintFlush(void);
 void AGBAssert(const char *pFile, int nLine, const char *pExpression, int nStopProgram);
+void AGBPrintInit(void);
+
+#if (LOG_HANDLER == LOG_HANDLER_MGBA_PRINT)
+
+#define DebugPrintf(pBuf, ...) MgbaPrintf(MGBA_LOG_INFO, pBuf, ## __VA_ARGS__)
+#define DebugAssert(pFile, nLine, pExpression, nStopProgram) MgbaAssert(pFile, nLine, pExpression, nStopProgram)
+#define DebugPrintfLevel(level, pBuf, ...) MgbaPrintf(level, pBuf, ## __VA_ARGS__)
+
+#elif (LOG_HANDLER == LOG_HANDLER_NOCASH_PRINT)
+
+#define DebugPrintf(pBuf, ...) NoCashGBAPrintf(pBuf, ## __VA_ARGS__)
+#define DebugAssert(pFile, nLine, pExpression, nStopProgram) NoCashGBAAssert(pFile, nLine, pExpression, nStopProgram)
+#define DebugPrintfLevel(level, pBuf, ...) NoCashGBAPrintf(pBuf, ## __VA_ARGS__)
+
+#else // Default to AGBPrint
+
+#define DebugPrintf(pBuf, ...) AGBPrintf(pBuf, ## __VA_ARGS__)
+#define DebugAssert(pFile, nLine, pExpression, nStopProgram) AGBAssert(pFile, nLine, pExpression, nStopProgram)
+#define DebugPrintfLevel(level, pBuf, ...) AGBPrintf(pBuf, ## __VA_ARGS__)
+
 #endif
-
-#undef AGB_ASSERT
-#ifdef NDEBUG
-#define	AGB_ASSERT(exp)
-#else
-#define	AGB_ASSERT(exp) (exp) ? ((void *)0) : AGBAssert(__FILE__, __LINE__, #exp, 1);
-#endif
-
-#undef AGB_WARNING
-#ifdef NDEBUG
-#define	AGB_WARNING(exp)
-#else
-#define	AGB_WARNING(exp) (exp) ? ((void *)0) : AGBAssert(__FILE__, __LINE__, #exp, 0);
-#endif
-
-// for matching purposes
-
-#if MODERN
-#define AGB_ASSERT_EX(exp, file, line) AGB_ASSERT(exp)
-#define AGB_WARNING_EX(exp, file, line) AGB_WARNING(exp)
-#else
-#ifdef NDEBUG
-#define	AGB_ASSERT_EX(exp, file, line)
-#else
-#define	AGB_ASSERT_EX(exp, file, line) (exp) ? ((void *)0) : AGBAssert(file, line, #exp, 1);
 #endif
 
 #ifdef NDEBUG
-#define	AGB_WARNING_EX(exp, file, line)
+
+#define AGB_ASSERT(exp)
+#define AGB_WARNING(exp)
+#define AGB_ASSERT_EX(exp, file, line)
+#define AGB_WARNING_EX(exp, file, line)
+
 #else
-#define	AGB_WARNING_EX(exp, file, line) (exp) ? ((void *)0) : AGBAssert(file, line, #exp, 0);
-#endif
+
+#define AGB_ASSERT(exp) (exp) ? ((void*)0) : DebugAssert(__FILE__, __LINE__, #exp, TRUE)
+#define AGB_WARNING(exp) (exp) ? ((void*)0) : DebugAssert(__FILE__, __LINE__, #exp, FALSE)
+
+#define AGB_WARNING_EX(exp, file, line) (exp) ? ((void *)0) : DebugAssert(file, line, #exp, FALSE);
+#define AGB_ASSERT_EX(exp, file, line) (exp) ? ((void *)0) : DebugAssert(file, line, #exp, TRUE);
+
 #endif
 
 #endif // GUARD_GBA_ISAGBPRINT_H

--- a/include/mini_printf.h
+++ b/include/mini_printf.h
@@ -1,0 +1,52 @@
+/*
+ * The Minimal snprintf() implementation
+ *
+ * Copyright (c) 2013 Michal Ludvig <michal@logix.cz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the auhor nor the names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Courtey of https://github.com/mludvig/mini-printf
+ * stripped to reduce file size for agb needs
+ */
+
+#ifndef __MINI_PRINTF__
+#define __MINI_PRINTF__
+
+#include <stdarg.h>
+#include "gba/types.h"
+
+#ifdef NDEBUG
+
+#define mini_vsnprintf(buffer, buffer_len, fmt, va)
+#define mini_vpprintf(buf, fmt, va)
+
+#else
+
+s32 mini_vsnprintf(char* buffer, u32 buffer_len, const char *fmt, va_list va);
+s32 mini_vpprintf(void* buf, const char *fmt, va_list va);
+
+#endif
+#endif

--- a/src/isagbprn.c
+++ b/src/isagbprn.c
@@ -2,6 +2,8 @@
 #include <stdio.h>
 #include "config.h"
 #include "gba/gba.h"
+#include "malloc.h"
+#include "mini_printf.h"
 
 #define AGB_PRINT_FLUSH_ADDR 0x9FE209D
 #define AGB_PRINT_STRUCT_ADDR 0x9FE20F8
@@ -13,6 +15,11 @@
 #define NOCASHGBAIDADDR 0x4FFFA00
 #define NOCASHGBAPRINTADDR1 0x4FFFA10 // automatically adds a newline after the string has finished
 #define NOCASHGBAPRINTADDR2 0x4FFFA14 // does not automatically add the newline. by default, NOCASHGBAPRINTADDR2 is used. this is used to keep strings consistent between no$gba and VBA-RR, but a user can choose to forgo this.
+
+// hardware extensions for LOG_HANDLER_MGBA_PRINT
+#define REG_DEBUG_ENABLE ((vu16*) (0x4FFF780)) // handshake: (w)[0xC0DE] -> (r)[0x1DEA]
+#define REG_DEBUG_FLAGS  ((vu16*) (0x4FFF700))
+#define REG_DEBUG_STRING ((char*) (0x4FFF600))
 
 struct AGBPrintStruct
 {
@@ -26,6 +33,8 @@ typedef void (*LPFN_PRINT_FLUSH)(void);
 
 #ifndef NDEBUG
 
+// AGBPrint print functions
+#if (LOG_HANDLER == LOG_HANDLER_AGB_PRINT)
 void AGBPrintFlush1Block(void);
 
 void AGBPrintInit(void)
@@ -87,7 +96,15 @@ void AGBPrintf(const char *pBuf, ...)
     char bufPrint[0x100];
     va_list vArgv;
     va_start(vArgv, pBuf);
+    #if (PRETTY_PRINT_HANDLER == PRETTY_PRINT_OFF)
     vsprintf(bufPrint, pBuf, vArgv);
+    #elif (PRETTY_PRINT_HANDLER == PRETTY_PRINT_MINI_PRINTF)
+    mini_vsnprintf(bufPrint, 0x100, pBuf, vArgv);
+    #elif (PRETTY_PRINT_HANDLER == PRETTY_PRINT_LIBC)
+    vsnprintf(bufPrint, 0x100, pBuf, vArgv);
+    #else
+    #error "unspecified pretty printing handler."
+    #endif
     va_end(vArgv);
     AGBPrint(bufPrint);
 }
@@ -155,9 +172,10 @@ void AGBAssert(const char *pFile, int nLine, const char *pExpression, int nStopP
         AGBPrintf("WARING FILE=[%s] LINE=[%d]  EXP=[%s] \n", pFile, nLine, pExpression);
     }
 }
+#endif
 
-// no$gba print functions, uncomment to use
-/*
+// no$gba print functions
+#if (LOG_HANDLER == LOG_HANDLER_NOCASH_PRINT)
 void NoCashGBAPrint(const char *pBuf)
 {
     *(volatile u32 *)NOCASHGBAPRINTADDR2 = (u32)pBuf;
@@ -168,10 +186,79 @@ void NoCashGBAPrintf(const char *pBuf, ...)
     char bufPrint[0x100];
     va_list vArgv;
     va_start(vArgv, pBuf);
+    #if (PRETTY_PRINT_HANDLER == PRETTY_PRINT_OFF)
     vsprintf(bufPrint, pBuf, vArgv);
+    #elif (PRETTY_PRINT_HANDLER == PRETTY_PRINT_MINI_PRINTF)
+    mini_vsnprintf(bufPrint, 0x100, pBuf, vArgv);
+    #elif (PRETTY_PRINT_HANDLER == PRETTY_PRINT_LIBC)
+    vsnprintf(bufPrint, 0x100, pBuf, vArgv);
+    #else
+    #error "unspecified pretty printing handler."
+    #endif
     va_end(vArgv);
     NoCashGBAPrint(bufPrint);
 }
-*/
+
+void NoCashGBAAssert(const char *pFile, s32 nLine, const char *pExpression, bool32 nStopProgram)
+{
+    if (nStopProgram)
+    {
+        NoCashGBAPrintf("ASSERTION FAILED  FILE=[%s] LINE=[%d]  EXP=[%s]", pFile, nLine, pExpression);
+        asm(".hword 0xEFFF");
+    }
+    else
+    {
+        NoCashGBAPrintf("WARING FILE=[%s] LINE=[%d]  EXP=[%s]", pFile, nLine, pExpression);
+    }
+}
+#endif
+
+// mgba print functions
+#if (LOG_HANDLER == LOG_HANDLER_MGBA_PRINT)
+#define MGBA_REG_DEBUG_MAX (256)
+
+bool32 MgbaOpen(void)
+{
+    *REG_DEBUG_ENABLE = 0xC0DE;
+    return *REG_DEBUG_ENABLE == 0x1DEA;
+}
+
+void MgbaClose(void)
+{
+    *REG_DEBUG_ENABLE = 0;
+}
+
+void MgbaPrintf(s32 level, const char* ptr, ...)
+{
+    va_list args;
+
+    level &= 0x7;
+    va_start(args, ptr);
+    #if (PRETTY_PRINT_HANDLER == PRETTY_PRINT_OFF)
+    vsprintf(REG_DEBUG_STRING, ptr, args);
+    #elif (PRETTY_PRINT_HANDLER == PRETTY_PRINT_MINI_PRINTF)
+    mini_vsnprintf(REG_DEBUG_STRING, MGBA_REG_DEBUG_MAX, ptr, args);
+    #elif (PRETTY_PRINT_HANDLER == PRETTY_PRINT_LIBC)
+    vsnprintf(REG_DEBUG_STRING, MGBA_REG_DEBUG_MAX, ptr, args);
+    #else
+    #error "unspecified pretty printing handler."
+    #endif
+    va_end(args);
+    *REG_DEBUG_FLAGS = level | 0x100;
+}
+
+void MgbaAssert(const char *pFile, s32 nLine, const char *pExpression, bool32 nStopProgram)
+{
+    if (nStopProgram)
+    {
+        MgbaPrintf(MGBA_LOG_ERROR, "ASSERTION FAILED  FILE=[%s] LINE=[%d]  EXP=[%s]", pFile, nLine, pExpression);
+        asm(".hword 0xEFFF");
+    }
+    else
+    {
+        MgbaPrintf(MGBA_LOG_WARN, "WARING FILE=[%s] LINE=[%d]  EXP=[%s]", pFile, nLine, pExpression);
+    }
+}
+#endif
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -70,12 +70,9 @@ u8 gPcmDmaCounter;
 
 // These variables are not defined in RS or Emerald, and are never read.
 // They were likely used to debug the audio engine and VCount interrupt.
-// Define NDEBUG in include/config.h to remove these variables.
-#ifndef NDEBUG
 u8 sVcountAfterSound;
 u8 sVcountAtIntr;
 u8 sVcountBeforeSound;
-#endif
 
 static IntrFunc * const sTimerIntrFunc = gIntrTable + 0x7;
 
@@ -146,7 +143,13 @@ void AgbMain()
 
     SetNotInSaveFailedScreen();
 
+#ifndef NDEBUG
+#if (LOG_HANDLER == LOG_HANDLER_MGBA_PRINT)
+    (void) MgbaOpen();
+#elif (LOG_HANDLER == LOG_HANDLER_AGB_PRINT)
     AGBPrintInit();
+#endif
+#endif
 
 #if REVISION == 1
     if (gFlashMemoryPresent != TRUE)

--- a/src/mini_printf.c
+++ b/src/mini_printf.c
@@ -143,7 +143,7 @@ static s32 mini_strlen(const char *s)
     return len;
 }
 
-static s32 mini_itoa(u32 value, u32 radix, s32 uppercase, bool32 unsig, char *buffer)
+static s32 mini_itoa(s32 value, u32 radix, s32 uppercase, bool32 unsig, char *buffer)
 {
     char *pbuffer = buffer;
     s32 negative = 0;

--- a/src/mini_printf.c
+++ b/src/mini_printf.c
@@ -1,0 +1,355 @@
+/*
+ * The Minimal snprintf() implementation
+ *
+ * Copyright (c) 2013,2014 Michal Ludvig <michal@logix.cz>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the auhor nor the names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * mini-printf courtesy of https://github.com/mludvig/mini-printf
+ * stripped to reduce file size for agb needs
+ */
+
+#include "mini_printf.h"
+#include "gba/types.h"
+#include "gba/defines.h"
+#include "config.h"
+#include "characters.h"
+#include "string_util.h"
+
+#ifndef NDEBUG
+#if (PRETTY_PRINT_HANDLER != PRETTY_PRINT_OFF)
+
+struct mini_buff 
+{
+    char *buffer, *pbuffer;
+    u32 buffer_len;
+};
+
+static inline char mini_pchar_decode(char encoded)
+{
+    char ret = '?';
+    if (encoded >= CHAR_a && encoded <= CHAR_z)
+        ret = encoded-(CHAR_a-'a'); // lower-case characters
+    else if (encoded >= CHAR_A && encoded <= CHAR_Z)
+        ret = encoded-(CHAR_A-'A'); // upper-case characters
+    else if (encoded >= CHAR_0 && encoded <= CHAR_9)
+        ret = encoded-(CHAR_0-'0'); // numbers
+    else if (encoded == CHAR_SPACE)
+        ret = ' '; // space
+    else if (encoded == CHAR_EXCL_MARK)
+        ret = '!'; // exclamation point
+    else if (encoded == CHAR_QUESTION_MARK)
+        ret = '?'; // question mark
+    else if (encoded == CHAR_PERIOD)
+        ret = '.'; // period
+    else if (encoded == CHAR_DBL_QUOTE_LEFT || encoded == CHAR_DBL_QUOTE_RIGHT)
+        ret = '"'; // double quote
+    else if (encoded == CHAR_SGL_QUOTE_LEFT || encoded == CHAR_SGL_QUOTE_RIGHT)
+        ret = '\''; // single quote
+    else if (encoded == CHAR_CURRENCY)
+        ret = '$'; // currency mark (pokemonies in game, dollar sign in logs)
+    else if (encoded == CHAR_COMMA)
+        ret = ','; // comma
+    else if (encoded == CHAR_MULT_SIGN)
+        ret = '#'; // pound, hashtag, octothorpe, whatever
+    else if (encoded == CHAR_SLASH)
+        ret = '/'; // slash
+    else if (encoded == CHAR_LESS_THAN)
+        ret = '<'; // less than sign
+    else if (encoded == CHAR_GREATER_THAN)
+        ret = '>'; // greater than sign
+    else if (encoded == CHAR_PERCENT)
+        ret = '%'; // percentage
+    else if (encoded == CHAR_LEFT_PAREN)
+        ret = '('; // opening parentheses
+    else if (encoded == CHAR_RIGHT_PAREN)
+        ret = ')'; // closing parentheses
+    return ret;
+}
+
+static s32 _putsAscii(char *s, s32 len, void *buf)
+{
+    char *p0;
+    s32 i;
+    struct mini_buff *b;
+
+    if (!buf) 
+        return len;
+
+    b = buf;
+    p0 = b->buffer;
+
+    /* Copy to buffer */
+    for (i = 0; i < len; i++) {
+        if(b->pbuffer == b->buffer + b->buffer_len - 1) {
+            break;
+        }
+        *(b->pbuffer ++) = s[i];
+    }
+    *(b->pbuffer) = 0;
+    return b->pbuffer - p0;
+}
+
+static s32 _putsEncoded(char *s, s32 len, void *buf)
+{
+    char *p0;
+    s32 i;
+    struct mini_buff *b;
+
+    if (!buf) 
+        return len;
+
+    b = buf;
+    p0 = b->buffer;
+
+    /* Copy to buffer */
+    for (i = 0; i < len; i++) {
+        if(b->pbuffer == b->buffer + b->buffer_len - 1) {
+            break;
+        }
+        *(b->pbuffer ++) = mini_pchar_decode(s[i]);
+    }
+    *(b->pbuffer) = 0;
+    return b->pbuffer - p0;
+}
+
+static s32 mini_strlen(const char *s)
+{
+    s32 len = 0;
+    while (s[len] != '\0') len++;
+    return len;
+}
+
+static s32 mini_itoa(u32 value, u32 radix, s32 uppercase, bool32 unsig, char *buffer)
+{
+    char *pbuffer = buffer;
+    s32 negative = 0;
+    s32 i, len;
+
+    /* No support for unusual radixes. */
+    if (radix > 16)
+        return 0;
+
+    if (value < 0 && !unsig)
+    {
+        negative = 1;
+        value = -value;
+    }
+
+    /* This builds the string back to front ... */
+    do 
+    {
+        s32 digit = value % radix;
+        *(pbuffer++) = (digit < 10 ? '0' + digit : (uppercase ? 'A' : 'a') + digit - 10);
+        value /= radix;
+    } while (value > 0);
+
+    if (negative)
+        *(pbuffer++) = '-';
+
+    *(pbuffer) = '\0';
+
+    /* ... now we reverse it (could do it recursively but will
+     * conserve the stack space) */
+    len = (pbuffer - buffer);
+    for (i = 0; i < len / 2; i++)
+    {
+        char j = buffer[i];
+        buffer[i] = buffer[len-i-1];
+        buffer[len-i-1] = j;
+    }
+
+    return len;
+}
+
+static s32 mini_pad(char* ptr, s32 len, char pad_char, s32 pad_to, char *buffer)
+{
+    s32 i;
+    bool32 overflow = FALSE;
+    char * pbuffer = buffer;
+    if(pad_to == 0)
+        pad_to = len;
+    if (len > pad_to) {
+        len = pad_to;
+        overflow = TRUE;
+    }
+    for(i = pad_to - len; i > 0; i --)
+    {
+        *(pbuffer++) = pad_char;
+    }
+    for(i = len; i > 0; i --)
+    {
+        *(pbuffer++) = *(ptr++);
+    }
+    len = pbuffer - buffer;
+    if(overflow)
+    {
+        for (i = 0; i < 3 && pbuffer > buffer; i ++)
+        {
+            *(pbuffer-- - 1) = '*';
+        }
+    }
+    return len;
+}
+
+s32 mini_vsnprintf(char *buffer, u32 buffer_len, const char *fmt, va_list va)
+{
+    struct mini_buff b;
+    s32 n;
+    b.buffer = buffer;
+    b.pbuffer = buffer;
+    b.buffer_len = buffer_len;
+    if (buffer_len == 0)
+        buffer = NULL;
+    n = mini_vpprintf((buffer != NULL) ? &b : NULL, fmt, va);
+    if (buffer == NULL)
+        return n;
+    return b.pbuffer - b.buffer;
+}
+
+s32 mini_vpprintf(void* buf, const char *fmt, va_list va)
+{
+    char bf[24];
+    char bf2[24];
+    char ch;
+    s32 n;
+    n = 0;
+    while ((ch=*(fmt++)))
+    {
+        s32 len;
+        if (ch != '%')
+        {
+            len = 1;
+            len = _putsAscii(&ch, len, buf);
+        } else 
+        {
+            char pad_char = ' ';
+            s32 pad_to = 0;
+            char l = 0;
+            char *ptr;
+
+            ch=*(fmt++);
+
+            /* Zero padding requested */
+            if (ch == '0')
+                pad_char = '0';
+            while (ch >= '0' && ch <= '9')
+            {
+                pad_to = pad_to * 10 + (ch - '0');
+                ch= *(fmt++);
+            }
+            if(pad_to > (s32) sizeof(bf))
+            {
+                pad_to = sizeof(bf);
+            }
+            if (ch == 'l')
+            {
+                l = 1;
+                ch=*(fmt++);
+            }
+
+            switch (ch) 
+            {
+                case 0:
+                    goto end;
+                case 'u':
+                case 'd':
+                    if(l)
+                    {
+                        len = mini_itoa(va_arg(va, u32), 10, 0, (ch=='u'), bf2);
+                    } else
+                    {
+                        if(ch == 'u')
+                        {
+                            len = mini_itoa((u32) va_arg(va, u32), 10, 0, 1, bf2);
+                        }
+                        else
+                        {
+                            len = mini_itoa((s32) va_arg(va, s32), 10, 0, 0, bf2);
+                        }
+                    }
+                    len = mini_pad(bf2, len, pad_char, pad_to, bf);
+                    len = _putsAscii(bf, len, buf);
+                    break;
+
+                case 'x':
+                case 'X':
+                    if(l)
+                    {
+                        len = mini_itoa(va_arg(va, u32), 16, (ch=='X'), 1, bf2);
+                    }
+                    else
+                    {
+                        len = mini_itoa((u32) va_arg(va, u32), 16, (ch=='X'), 1, bf2);
+                    }
+                    len = mini_pad(bf2, len, pad_char, pad_to, bf);
+                    len = _putsAscii(bf, len, buf);
+                    break;
+
+                case 'c' :
+                    ch = (char)(va_arg(va, s32));
+                    len = mini_pad(&ch, 1, pad_char, pad_to, bf);
+                    len = _putsAscii(bf, len, buf);
+                    break;
+
+                case 's' :
+                    ptr = va_arg(va, char*);
+                    len = mini_strlen(ptr);
+                    if (pad_to > 0)
+                    {
+                        len = mini_pad(ptr, len, pad_char, pad_to, bf);
+                        len = _putsAscii(bf, len, buf);
+                    } else
+                    {
+                        len = _putsAscii(ptr, len, buf);
+                    }
+                    break;
+                case 'S' : // preproc encoded string handler
+                    ptr = va_arg(va, char*);
+                    len = StringLength(ptr);
+                    if (pad_to > 0)
+                    {
+                        len = mini_pad(ptr, len, pad_char, pad_to, bf);
+                        len = _putsEncoded(bf, len, buf);
+                    } else
+                    {
+                        len = _putsEncoded(ptr, len, buf);
+                    }
+                    break;
+                default:
+                    len = 1;
+                    len = _putsAscii(&ch, len, buf);
+                    break;
+            }
+        }
+        n = n + len;
+    }
+end:
+    return n;
+}
+
+#endif
+#endif


### PR DESCRIPTION
Syncing changes from https://github.com/pret/pokeemerald/pull/1768, https://github.com/pret/pokeemerald/pull/1827, and https://github.com/pret/pokeemerald/commit/603d870ea0f4fb510a894bde4a1f999a021c9ac9

Point of difference: because FR/LG don't have `NDEBUG` defined by default, for matching purposes `LOG_HANDLER` has been set to `LOG_HANDLER_AGB_PRINT` instead of `LOG_HANDLER_MGBA_PRINT` and `PRETTY_PRINT_HANDLER` has been set to a new `PRETTY_PRINT_OFF` instead of `PRETTY_PRINT_MINI_PRINTF`.

Additionally, the repo wouldn't compile with `NDEBUG` defined because the linker expected the symbols defined in `common_syms/main.txt` to exist, so the conditional there was removed.