### PR TITLE
Red and Leaf back palettes swapped

### DIFF
--- a/src/data/graphics/trainers.h
+++ b/src/data/graphics/trainers.h
@@ -450,7 +450,7 @@ const u8 gTrainerBackPic_OldMan[] = INCBIN_U8("graphics/trainers/back_pics/old_m
 const u8 gTrainerBackPic_RSBrendan[] = INCBIN_U8("graphics/trainers/back_pics/ruby_sapphire_brendan_back_pic.4bpp");
 const u8 gTrainerBackPic_RSMay[] = INCBIN_U8("graphics/trainers/back_pics/ruby_sapphire_may_back_pic.4bpp");
 
-const u32 gTrainerPalette_RedBackPic[] = INCBIN_U32("graphics/trainers/palettes/leaf_back_pic.gbapal.lz");
-const u32 gTrainerPalette_LeafBackPic[] = INCBIN_U32("graphics/trainers/palettes/red_back_pic.gbapal.lz");
+const u32 gTrainerPalette_RedBackPic[] = INCBIN_U32("graphics/trainers/palettes/red_back_pic.gbapal.lz");
+const u32 gTrainerPalette_LeafBackPic[] = INCBIN_U32("graphics/trainers/palettes/leaf_back_pic.gbapal.lz");
 const u32 gTrainerPalette_PokedudeBackPic[] = INCBIN_U32("graphics/trainers/palettes/pokedude_back_pic.gbapal.lz");
 const u32 gTrainerPalette_OldManBackPic[] = INCBIN_U32("graphics/trainers/palettes/old_man_back_pic.gbapal.lz");


### PR DESCRIPTION
Not sure if maybe this is an idiosyncrasy of pkmn fire red, but it looks like it's probably just a typo; Red and Leaf each use the other's back pic palette