### PR TITLE
Ensure Alignment for Map Events

### DIFF
--- a/data/map_events.s
+++ b/data/map_events.s
@@ -14,4 +14,5 @@
 
     .section .rodata
 
+    .align 2
     .include "data/maps/events.inc"

--- a/data/map_events.s
+++ b/data/map_events.s
@@ -14,5 +14,4 @@
 
     .section .rodata
 
-    .align 2
     .include "data/maps/events.inc"

--- a/tools/mapjson/mapjson.cpp
+++ b/tools/mapjson/mapjson.cpp
@@ -195,7 +195,7 @@ string generate_map_events_text(Json map_data) {
 
     string mapName = json_to_string(map_data, "name");
 
-    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" << mapName << "/map.json\n@\n\n";
+    text << "@\n@ DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/" << mapName << "/map.json\n@\n\n\t.align 2\n\n";
 
     string objects_label, warps_label, coords_label, bgs_label;
 


### PR DESCRIPTION
As we discovered, map event scripts must be aligned to 4 bytes; this happens naturally in vanilla, so there were never any explicit alignment directives added, but when using the modern linkerscript, there is no such guarantee. The alignment is now guaranteed in two places: both at the start of the overall map event data blob and at the start of each map `events.inc` file. Theoretically, just aligning the data blob should be enough to ensure alignment for every map script, so this may be excessive, but it could be helpful if someone does some weird unlikely change down the line (though I fail to think of a use case that would necessitate such a change).