### PR TITLE
Linkerscript now tracks RAM/ROM usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ $(OBJ_DIR)/sym_common.ld: sym_common.txt $(C_OBJS) $(wildcard common_syms/*.txt)
 	$(RAMSCRGEN) COMMON $< ENGLISH -c $(C_BUILDDIR),common_syms > $@
 
 $(OBJ_DIR)/sym_ewram.ld: sym_ewram.txt
-	$(RAMSCRGEN) ewram_data $< ENGLISH > $@
+	$(RAMSCRGEN) .sbss $< ENGLISH > $@
 
 ifeq ($(MODERN),0)
 LD_SCRIPT := ld_script.ld
@@ -335,7 +335,7 @@ LD_SCRIPT_DEPS :=
 endif
 
 $(ELF): $(LD_SCRIPT) $(LD_SCRIPT_DEPS) $(OBJS)
-	@cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ../../$< -o ../../$@ $(OBJS_REL) $(LIB)
+	@cd $(OBJ_DIR) && $(LD) $(LDFLAGS) -T ../../$< --print-memory-usage -o ../../$@ $(OBJS_REL) $(LIB) | cat
 	$(FIX) $@ -t"$(TITLE)" -c$(GAME_CODE) -m$(MAKER_CODE) -r$(GAME_REVISION) --silent
 
 $(ROM): $(ELF)

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ $(OBJ_DIR)/sym_common.ld: sym_common.txt $(C_OBJS) $(wildcard common_syms/*.txt)
 	$(RAMSCRGEN) COMMON $< ENGLISH -c $(C_BUILDDIR),common_syms > $@
 
 $(OBJ_DIR)/sym_ewram.ld: sym_ewram.txt
-	$(RAMSCRGEN) .sbss $< ENGLISH > $@
+	$(RAMSCRGEN) ewram_data $< ENGLISH > $@
 
 ifeq ($(MODERN),0)
 LD_SCRIPT := ld_script.ld

--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -11,7 +11,7 @@
 #define EWRAM_DATA __attribute__((section("__DATA,ewram_data")))
 #else
 #define IWRAM_DATA __attribute__((section("iwram_data")))
-#define EWRAM_DATA __attribute__((section(".sbss")))
+#define EWRAM_DATA __attribute__((section("ewram_data")))
 #endif
 
 #if MODERN

--- a/include/gba/defines.h
+++ b/include/gba/defines.h
@@ -11,7 +11,7 @@
 #define EWRAM_DATA __attribute__((section("__DATA,ewram_data")))
 #else
 #define IWRAM_DATA __attribute__((section("iwram_data")))
-#define EWRAM_DATA __attribute__((section("ewram_data")))
+#define EWRAM_DATA __attribute__((section(".sbss")))
 #endif
 
 #if MODERN
@@ -71,6 +71,8 @@
 
 #define TILE_SIZE_4BPP 32
 #define TILE_SIZE_8BPP 64
+
+#define BG_TILE_ADDR_4BPP(n)   (void *)(BG_VRAM + (TILE_SIZE_4BPP * (n)))
 
 #define TILE_OFFSET_4BPP(n) ((n) * TILE_SIZE_4BPP)
 #define TILE_OFFSET_8BPP(n) ((n) * TILE_SIZE_8BPP)

--- a/ld_script.ld
+++ b/ld_script.ld
@@ -1,10 +1,16 @@
 gNumMusicPlayers = 4;
 gMaxLines = 0;
 
-SECTIONS {
-    . = 0x2000000;
+MEMORY
+{
+    EWRAM (rwx) : ORIGIN = 0x2000000, LENGTH = 256K
+    IWRAM (rwx) : ORIGIN = 0x3000000, LENGTH = 32K
+    ROM    (rx) : ORIGIN = 0x8000000, LENGTH = 32M
+}
 
-    ewram (NOLOAD) :
+SECTIONS {
+
+    .ewram.sbss 0x2000000 (NOLOAD) :
     ALIGN(4)
     {
         gHeap = .;
@@ -12,17 +18,14 @@ SECTIONS {
         . = 0x1C000;
 
         INCLUDE "sym_ewram.ld"
-        src/*.o(ewram_data);
+        src/*.o(.sbss);
 
         *libc.a:impure.o(.data);
         *libc.a:locale.o(.data);
         *libc.a:mallocr.o(.data);
-        . = 0x40000;
-    }
+    } > EWRAM
 
-    . = 0x3000000;
-
-    iwram (NOLOAD) :
+    iwram 0x3000000 (NOLOAD) :
     ALIGN(4)
     {
         /* .bss starts at 0x3000000 */
@@ -38,10 +41,9 @@ SECTIONS {
 
         *libc.a:sbrkr.o(COMMON);
         end = .;
+    } > IWRAM
 
-        . = 0x8000;
-    }
-
+    /* BEGIN ROM DATA */
     . = 0x8000000;
 
     .text :
@@ -307,7 +309,7 @@ SECTIONS {
         src/berry_powder.o(.text);
         src/minigame_countdown.o(.text);
         src/berry_fix_program.o(.text);
-    } =0
+    } > ROM =0
 
     script_data :
     ALIGN(4)
@@ -319,7 +321,7 @@ SECTIONS {
         data/battle_scripts_2.o(script_data);
         data/battle_ai_scripts.o(script_data);
         data/mystery_event_script_cmd_table.o(script_data);
-    } =0
+    } > ROM =0
 
     lib_text :
     ALIGN(4)
@@ -388,7 +390,7 @@ SECTIONS {
         *libc.a:libcfunc.o(.text);
         *libc.a:lseekr.o(.text);
         *libc.a:readr.o(.text);
-    } =0
+    } > ROM =0
 
     .rodata :
     SUBALIGN(4)
@@ -608,7 +610,7 @@ SECTIONS {
         data/mystery_event_msg.o(.rodata);
         src/m4a_tables.o(.rodata);
         data/sound_data.o(.rodata);
-    } =0
+    } > ROM =0
 
     song_data :
     ALIGN(4)
@@ -960,7 +962,7 @@ SECTIONS {
         sound/songs/midi/mus_trainer_tower.o(.rodata);
         sound/songs/midi/mus_slow_pallet.o(.rodata);
         sound/songs/midi/mus_teachy_tv_menu.o(.rodata);
-    }
+    } > ROM =0
 
     lib_rodata :
     SUBALIGN(4)
@@ -1013,7 +1015,7 @@ SECTIONS {
         *libc.a:readr.o(.rodata);
 
         . = ALIGN(4);
-    } =0
+    } > ROM =0
 
     multiboot_data :
     ALIGN(4)
@@ -1021,14 +1023,13 @@ SECTIONS {
         data/multiboot_ereader.o(.rodata);
         data/multiboot_berry_glitch_fix.o(.rodata);
         data/multiboot_pokemon_colosseum.o(.rodata);
-    } =0
+    } > ROM =0
 
-    . = 0x08D00000;
-    gfx_data :
+    gfx_data 0x08D00000 :
     ALIGN(4)
     {
         src/graphics.o(.rodata);
-    } =0
+    } > ROM =0
 
     extra :
     ALIGN(4)
@@ -1036,7 +1037,8 @@ SECTIONS {
         src/*.o(.text);
         src/*.o(.rodata);
         data/*.o(.rodata);
-    } = 0
+    } > ROM =0
+
 
     /* DWARF 2 sections */
     .debug_aranges  0 : { *(.debug_aranges) }

--- a/ld_script.ld
+++ b/ld_script.ld
@@ -10,7 +10,7 @@ MEMORY
 
 SECTIONS {
 
-    .ewram.sbss 0x2000000 (NOLOAD) :
+    ewram 0x2000000 (NOLOAD) :
     ALIGN(4)
     {
         gHeap = .;
@@ -18,7 +18,7 @@ SECTIONS {
         . = 0x1C000;
 
         INCLUDE "sym_ewram.ld"
-        src/*.o(.sbss);
+        src/*.o(ewram_data);
 
         *libc.a:impure.o(.data);
         *libc.a:locale.o(.data);

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -10,14 +10,14 @@ MEMORY
 
 SECTIONS {
 
-    .ewram.sbss 0x2000000 (NOLOAD) :
+    ewram 0x2000000 (NOLOAD) :
     ALIGN(4)
     {
         gHeap = .;
 
         . = 0x1C000;
 
-        *(.sbss);
+        *(ewram_data);
     } > EWRAM
 
     iwram 0x3000000 (NOLOAD) :

--- a/ld_script_modern.ld
+++ b/ld_script_modern.ld
@@ -1,24 +1,26 @@
 gNumMusicPlayers = 4;
 gMaxLines = 0;
 
-SECTIONS {
-    . = 0x2000000;
+MEMORY
+{
+    EWRAM (rwx) : ORIGIN = 0x2000000, LENGTH = 256K
+    IWRAM (rwx) : ORIGIN = 0x3000000, LENGTH = 32K
+    ROM    (rx) : ORIGIN = 0x8000000, LENGTH = 32M
+}
 
-    ewram (NOLOAD) :
+SECTIONS {
+
+    .ewram.sbss 0x2000000 (NOLOAD) :
     ALIGN(4)
     {
         gHeap = .;
 
         . = 0x1C000;
 
-        *(ewram_data);
+        *(.sbss);
+    } > EWRAM
 
-        . = 0x40000;
-    }
-
-    . = 0x3000000;
-
-    iwram (NOLOAD) :
+    iwram 0x3000000 (NOLOAD) :
     ALIGN(4)
     {
         /* .bss starts at 0x3000000 */
@@ -30,8 +32,7 @@ SECTIONS {
         *(COMMON);
         end = .;
         __end__ = .;
-        . = 0x8000;
-    }
+    } > IWRAM
 
     . = 0x8000000;
 
@@ -43,25 +44,25 @@ SECTIONS {
         src/crt0.o(.text);
         src/main.o(.text);
         *(.text*);
-    } =0
+    } > ROM =0
 
     script_data :
     ALIGN(4)
     {
     	*(script_data);
-    } =0
+    } > ROM =0
 
     .data :
     ALIGN(4)
     {
     	*(.data*);
-    } =0
+    } > ROM =0
 
     .rodata :
     ALIGN(4)
     {
     	*(.rodata*);
-    } =0
+    } > ROM =0
 
     /* DWARF 2 sections */
     .debug_aranges  0 : { *(.debug_aranges) }


### PR DESCRIPTION
Ported this from pokeemerald: https://github.com/pret/pokeemerald/pull/1952

No dependencies on other PRs

## Description
- The linkerscript should warn if memory bounds are exceeded.
- Running `make` now prints memory usages

Example output:
```bash
Memory region         Used Size  Region Size  %age Used
           EWRAM:      261040 B       256 KB     99.58%
           IWRAM:         32 KB        32 KB    100.00%
             ROM:    15403808 B        32 MB     45.91%
```

**Discord contact info**
merrp

