### PR TITLE
BUGFIX for Localization Oversight in Daisy's Text && Fix Typo in Nurse Script

### DIFF
--- a/data/maps/PalletTown_RivalsHouse/text.inc
+++ b/data/maps/PalletTown_RivalsHouse/text.inc
@@ -62,8 +62,13 @@ PalletTown_RivalsHouse_Text_LookingNiceInNoTime::
     .string "nice in no time.$"
 
 PalletTown_RivalsHouse_Text_ThereYouGoAllDone::
+.ifdef BUGFIX @ The localizers missed what should be a textcolor change in the localizations.
+    .string "{COLOR DARK_GRAY}{STR_VAR_1} looks dreamily content…\p"
+    .string "{COLOR RED}DAISY: There you go! All done.\n"
+.else @ In the JP games, gender-based text used a different font instead of different colors.
     .string "{FONT_NORMAL}{STR_VAR_1} looks dreamily content…\p"
     .string "{FONT_FEMALE}DAISY: There you go! All done.\n"
+.endif
     .string "See? Doesn't it look nice?\p"
     .string "Giggle…\n"
     .string "It's such a cute POKéMON.$"

--- a/data/maps/PalletTown_RivalsHouse/text.inc
+++ b/data/maps/PalletTown_RivalsHouse/text.inc
@@ -62,13 +62,13 @@ PalletTown_RivalsHouse_Text_LookingNiceInNoTime::
     .string "nice in no time.$"
 
 PalletTown_RivalsHouse_Text_ThereYouGoAllDone::
-.ifdef BUGFIX @ The localizers missed what should be a textcolor change in the localizations.
+#ifdef BUGFIX @ The localizers missed what should be a textcolor change in the localizations.
     .string "{COLOR DARK_GRAY}{STR_VAR_1} looks dreamily content…\p"
     .string "{COLOR RED}DAISY: There you go! All done.\n"
-.else @ In the JP games, gender-based text used a different font instead of different colors.
+#else @ In the JP games, gender-based text used a different font instead of different colors.
     .string "{FONT_NORMAL}{STR_VAR_1} looks dreamily content…\p"
     .string "{FONT_FEMALE}DAISY: There you go! All done.\n"
-.endif
+#endif
     .string "See? Doesn't it look nice?\p"
     .string "Giggle…\n"
     .string "It's such a cute POKéMON.$"

--- a/data/scripts/pkmn_center_nurse.inc
+++ b/data/scripts/pkmn_center_nurse.inc
@@ -34,7 +34,7 @@ EventScript_PkmnCenterNurse_CheckTrainerTowerAndUnionRoom::
 	specialvar VAR_RESULT, BufferUnionRoomPlayerName
 	copyvar VAR_0x8008, VAR_RESULT
 	goto_if_eq VAR_0x8008, 0, EventScript_PkmnCenterNurse_ReturnPkmn
-	goto_if_eq VAR_0x8008, 1, EventScript_PkmnCenterNurse_PlayerWaitingInUionRoom
+	goto_if_eq VAR_0x8008, 1, EventScript_PkmnCenterNurse_PlayerWaitingInUnionRoom
 	end
 
 EventScript_PkmnCenterNurse_ReturnPkmn::
@@ -45,7 +45,7 @@ EventScript_PkmnCenterNurse_ReturnPkmn::
 	msgbox Text_WeHopeToSeeYouAgain
 	return
 
-EventScript_PkmnCenterNurse_PlayerWaitingInUionRoom::
+EventScript_PkmnCenterNurse_PlayerWaitingInUnionRoom::
 	goto_if_set FLAG_SYS_INFORMED_OF_LOCAL_WIRELESS_PLAYER, EventScript_PkmnCenterNurse_ReturnPkmn
 	msgbox Text_RestoredPkmnToFullHealth
 	setflag FLAG_SYS_INFORMED_OF_LOCAL_WIRELESS_PLAYER


### PR DESCRIPTION
**Fix Localization Oversight in Daisy's Text:**
Based on the FONT_NORMAL and FONT_FEMALE control codes in Daisy's text when finishing her grooming of a Pokémon, it seems the original intention was for the first part of this text to be NPC_TEXT_COLOR_NEUTRAL and for Daisy's dialogue to be NPC_TEXT_COLOR_FEMALE. If the localizers had caught it, they would've replaced FONT_NORMAL with COLOR DARK_GRAY and FONT_FEMALE with COLOR RED. This commit creates a .ifdef BUGFIX for this oversight.

For reference, all the localization languages make this error, not just English.

**Fix Typo in Nurse Script:**
EventScript_PkmnCenterNurse_PlayerWaitingInUionRoom => EventScript_PkmnCenterNurse_PlayerWaitingInUnionRoom