### PR TITLE
Fix Compilation on GCC 14

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -9,8 +9,8 @@ extern const u8 gMiscBlank_Gfx[]; // unused in Emerald
 extern const u32 gBitTable[];
 
 u8 CreateInvisibleSpriteWithCallback(void (*)(struct Sprite *));
-void StoreWordInTwoHalfwords(u16 *, unsigned);
-void LoadWordFromTwoHalfwords(u16 *, unsigned *);
+void StoreWordInTwoHalfwords(u16 *, u32);
+void LoadWordFromTwoHalfwords(u16 *, u32 *);
 int CountTrailingZeroBits(u32 value);
 u16 CalcCRC16(const u8 *data, u32 length);
 u16 CalcCRC16WithTable(const u8 *data, u32 length);

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -2711,7 +2711,7 @@ static void ShowMonEffect_Outdoors_6(struct Task *task)
 static void ShowMonEffect_Outdoors_7(struct Task *task)
 {
     IntrCallback callback;
-    LoadWordFromTwoHalfwords((u16 *)&task->data[13], (uintptr_t *)&callback);
+    LoadWordFromTwoHalfwords((u16 *)&task->data[13], (u32 *)&callback);
     SetVBlankCallback(callback);
     ChangeBgX(0, 0, 0);
     ChangeBgY(0, 0, 0);
@@ -2725,7 +2725,7 @@ static void VBlankCB_ShowMonEffect_Outdoors(void)
 {
     IntrCallback callback;
     struct Task *task = &gTasks[FindTaskIdByFunc(Task_ShowMon_Outdoors)];
-    LoadWordFromTwoHalfwords((u16 *)&task->data[13], (uintptr_t *)&callback);
+    LoadWordFromTwoHalfwords((u16 *)&task->data[13], (u32 *)&callback);
     callback();
     SetGpuReg(REG_OFFSET_WIN0H, task->data[1]);
     SetGpuReg(REG_OFFSET_WIN0V, task->data[2]);
@@ -2830,7 +2830,7 @@ static void ShowMonEffect_Indoors_7(struct Task *task)
     u16 charbase;
     charbase = (GetGpuReg(REG_OFFSET_BG0CNT) >> 8) << 11;
     CpuFill32(0, (void *)VRAM + charbase, 0x800);
-    LoadWordFromTwoHalfwords((u16 *)&task->data[13], (uintptr_t *)&intrCallback);
+    LoadWordFromTwoHalfwords((u16 *)&task->data[13], (u32 *)&intrCallback);
     SetVBlankCallback(intrCallback);
     ChangeBgX(0, 0, 0);
     ChangeBgY(0, 0, 0);
@@ -2845,7 +2845,7 @@ static void VBlankCB_ShowMonEffect_Indoors(void)
     IntrCallback intrCallback;
     struct Task *task;
     task = &gTasks[FindTaskIdByFunc(Task_ShowMon_Indoors)];
-    LoadWordFromTwoHalfwords((u16 *)&task->data[13], (uintptr_t *)&intrCallback);
+    LoadWordFromTwoHalfwords((u16 *)&task->data[13], (u32 *)&intrCallback);
     intrCallback();
     SetGpuReg(REG_OFFSET_BG0HOFS, task->data[1]);
     SetGpuReg(REG_OFFSET_BG0VOFS, task->data[2]);

--- a/src/trainer_see.c
+++ b/src/trainer_see.c
@@ -518,7 +518,7 @@ static void Task_RevealTrainer_RunTrainerSeeFuncList(u8 taskId)
     struct ObjectEvent * trainerObj;
 
     // another objEvent loaded into by loadword?
-    LoadWordFromTwoHalfwords((u16 *)&task->data[1], (uintptr_t *)&trainerObj);
+    LoadWordFromTwoHalfwords((u16 *)&task->data[1], (u32 *)&trainerObj);
     if (!task->data[7])
     {
         ObjectEventClearHeldMovement(trainerObj);

--- a/src/util.c
+++ b/src/util.c
@@ -120,13 +120,13 @@ u8 CreateInvisibleSpriteWithCallback(void (*callback)(struct Sprite *))
     return sprite;
 }
 
-void StoreWordInTwoHalfwords(u16 *h, unsigned w)
+void StoreWordInTwoHalfwords(u16 *h, u32 w)
 {
     h[0] = (u16)(w);
     h[1] = (u16)(w >> 16);
 }
 
-void LoadWordFromTwoHalfwords(u16 *h, unsigned *w)
+void LoadWordFromTwoHalfwords(u16 *h, u32 *w)
 {
     *w = h[0] | (s16)h[1] << 16;
 }


### PR DESCRIPTION
GCC 14 treats implicit pointer conversions as errors, so edits are needed to compile in modern. However, this is already how we're doing it in pokeemerald anyway, so this is more of a sync than anything.