### PR TITLE
UB fix in battle_transition.c

### DIFF
--- a/src/battle_transition.c
+++ b/src/battle_transition.c
@@ -1230,7 +1230,11 @@ static bool8 ClockwiseWipe_Init(struct Task *task)
 static bool8 ClockwiseWipe_TopRight(struct Task *task)
 {
     sTransitionData->vblankDma = FALSE;
+#ifdef UBFIX
+    InitBlackWipe(sTransitionData->data, DISPLAY_WIDTH / 2, DISPLAY_HEIGHT / 2, sTransitionData->tWipeEndX, 0, 1, 1);
+#else
     InitBlackWipe(sTransitionData->data, DISPLAY_WIDTH / 2, DISPLAY_HEIGHT / 2, sTransitionData->tWipeEndX, -1, 1, 1);
+#endif
     do
     {
         gScanlineEffectRegBuffers[0][sTransitionData->tWipeCurrY] = WIN_RANGE(DISPLAY_WIDTH / 2, sTransitionData->tWipeCurrX + 1);


### PR DESCRIPTION
## Description
When starting a wild cave encounter `InitBlackWipe` is called in `ClockwiseWipe_TopRight` with -1 for `endY`. This results in `sTransitionData->tWipeCurrY` ending up being -1 aswell, which is then used to access `gScanlineEffectRegBuffers[0][sTransitionData->tWipeCurrY]` leading to UB.

## **Discord contact info**
.cawt