### PR TITLE
Fix for potential UB in CameraObjectReset2

### DIFF
--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2453,7 +2453,15 @@ u8 CameraObjectGetFollowedObjectId(void)
 
 void CameraObjectReset2(void)
 {
+#ifdef UBFIX
+    struct Sprite* cameraObject = FindCameraObject();
+
+    if (cameraObject == NULL)
+        return;
+    cameraObject->data[1] = 2;
+#else
     FindCameraObject()->data[1] = 2;
+#endif
 }
 
 u8 CopySprite(struct Sprite *sprite, s16 x, s16 y, u8 subpriority)

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2453,15 +2453,12 @@ u8 CameraObjectGetFollowedObjectId(void)
 
 void CameraObjectReset2(void)
 {
+    struct Sprite *cameraObject = FindCameraObject();
 #ifdef UBFIX
-    struct Sprite* cameraObject = FindCameraObject();
-
     if (cameraObject == NULL)
         return;
-    cameraObject->data[1] = 2;
-#else
-    FindCameraObject()->data[1] = 2;
 #endif
+    cameraObject->data[1] = 2;
 }
 
 u8 CopySprite(struct Sprite *sprite, s16 x, s16 y, u8 subpriority)


### PR DESCRIPTION
`FindCameraObject` can return `NULL`. Other functions handle this. Not sure if this can ever occur in vanilla.