### PR TITLE
Decode unused JP text

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -813,8 +813,8 @@ static const u8 sBallCatchBonuses[] =
     [ITEM_SAFARI_BALL - ITEM_ULTRA_BALL] = 15
 };
 
-// unknown unused data
-static const u32 sUnused = 0xFF7EAE60;
+// unused
+ALIGNED(4) static const u8 sJPText_Turn[] = _("ターン");
 
 static void Cmd_attackcanceler(void)
 {

--- a/src/mon_markings.c
+++ b/src/mon_markings.c
@@ -19,7 +19,7 @@ static struct Sprite *CreateMarkingComboSprite(u16, u16, const u16 *, u16);
 
 static const u16 sMonMarkings_Pal[] = INCBIN_U16("graphics/misc/mon_markings.gbapal");
 static const u16 sMonMarkings_Gfx[] = INCBIN_U16("graphics/misc/mon_markings.4bpp");
-static const u8 sUnused[] = {0x09, 0x50, 0x13, 0x02, 0xFF};
+static const u8 sJPText_Confirm[] = _("けってい");
 
 static const struct OamData sOamData_MenuWindow =
 {


### PR DESCRIPTION
Decodes the following values as Japanese text:
- `sUnused` in `battle_script_commands.c` is unused Japanese text for "Turn". It's also [present in Ruby/Sapphire](https://github.com/pret/pokeruby/blob/714bd0ac0e38fa4ee51a11f7679ea91f6ce6762b/src/battle_controller_player.c#L229), where it's used in [debug code](https://github.com/pret/pokeruby/blob/714bd0ac0e38fa4ee51a11f7679ea91f6ce6762b/src/battle_controller_player.c#L756).
- `sUnused` in `mon_markings.c` is unused Japanese text for "Confirm". 