### PR TITLE
Update link_rfu_2.c

### DIFF
--- a/src/link_rfu_2.c
+++ b/src/link_rfu_2.c
@@ -1831,7 +1831,7 @@ static void ReceiveRfuLinkPlayers(const struct SioInfo *sioInfo)
 
 // Could be relocated to top of file, but would also require relocating assert strings
 static const char sASCII_PokemonSioInfo[] = "PokemonSioInfo";
-static const u8 sText_Akito[] = _("　あきと"); // Presumably "Akito Mori", one of Game Freak's programmers
+ALIGNED(4) static const u8 sText_Akito[] = _("あきと"); // Presumably "Akito Mori", one of Game Freak's programmers
 static const char sASCII_LinkLossDisconnect[] = "LINK LOSS DISCONNECT!";
 static const char sASCII_LinkLossRecoveryNow[] = "LINK LOSS RECOVERY NOW";
 ALIGNED(4) static const char sASCII_30Spaces[] = {"                              "};


### PR DESCRIPTION
Treat `sText_Akito` as being 4-byte aligned rather than having a leading space, since it is 4-byte aligned in every language/version of FRLG and the [equivalent string in RS](https://github.com/pret/pokeruby/blob/714bd0ac0e38fa4ee51a11f7679ea91f6ce6762b/src/move_tutor_menu.c#L231) does not have a leading space.