### PR TITLE
Rename the Move Relearner specials

### DIFF
--- a/data/maps/TwoIsland_House/scripts.inc
+++ b/data/maps/TwoIsland_House/scripts.inc
@@ -48,7 +48,7 @@ TwoIsland_House_EventScript_AskTutorMon::
 
 TwoIsland_House_EventScript_ChooseMonToTutor::
 	msgbox TwoIsland_House_Text_TutorWhichMon
-	special SelectMoveTutorMon
+	special ChooseMonForMoveRelearner
 	waitstate
 	goto_if_ge VAR_0x8004, PARTY_SIZE, TwoIsland_House_EventScript_EndTutorMove
 	special IsSelectedMonEgg
@@ -59,7 +59,7 @@ TwoIsland_House_EventScript_ChooseMonToTutor::
 
 TwoIsland_House_EventScript_ChooseMoveToTeach::
 	msgbox TwoIsland_House_Text_TeachWhichMove
-	special DisplayMoveTutorMenu
+	special TeachMoveRelearnerMove
 	waitstate
 	goto_if_eq VAR_0x8004, 0, TwoIsland_House_EventScript_ChooseMonToTutor
 	goto_if_set HAS_BOTH_MUSHROOMS, TwoIsland_House_EventScript_ChooseMushroom

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -227,12 +227,12 @@ gSpecials::
 	def_special GetElevatorFloor
 	def_special NullFieldSpecial  @ Lottery Corner specials
 	def_special NullFieldSpecial
-	def_special SelectMoveTutorMon
+	def_special ChooseMonForMoveRelearner
 	def_special SelectMoveDeleterMove
 	def_special MoveDeleterForgetMove
 	def_special BufferMoveDeleterNicknameAndMove
 	def_special GetNumMovesSelectedMonHas
-	def_special DisplayMoveTutorMenu
+	def_special TeachMoveRelearnerMove
 	def_special NullFieldSpecial  @ Hoenn Cycling Road specials
 	def_special NullFieldSpecial
 	def_special GetPlayerAvatarBike

--- a/src/learn_move.c
+++ b/src/learn_move.c
@@ -364,7 +364,7 @@ static void VBlankCB_MoveRelearner(void)
     TransferPlttBuffer();
 }
 
-void DisplayMoveTutorMenu(void)
+void TeachMoveRelearnerMove(void)
 {
     LockPlayerFieldControls();
     CreateTask(Task_InitMoveRelearnerMenu, 10);

--- a/src/party_menu_specials.c
+++ b/src/party_menu_specials.c
@@ -21,7 +21,7 @@ void ChoosePartyMon(void)
     BeginNormalPaletteFade(PALETTES_ALL, 0, 0, 0x10, RGB_BLACK);
 }
 
-void SelectMoveTutorMon(void)
+void ChooseMonForMoveRelearner(void)
 {
     u8 taskId;
 


### PR DESCRIPTION
This renames `SelectMoveTutorMon` and `DisplayMoveTutorMenu` to `ChooseMonForMoveRelearner` and `TeachMoveRelearnerMove`, respectively.

This is how they're named in pokeemerald, and it avoids `SelectMoveTutorMon` from being confused with the similar  `ChooseMonForMoveTutor`.