### PR TITLE
Caution for rfu_waitREQComplete

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -184,6 +184,9 @@ void AgbMain()
          && (gMain.heldKeysRaw & B_START_SELECT) == B_START_SELECT)
         {
             rfu_REQ_stopMode();
+
+            // Note: This is an emulation hack for sloop. Do not remove if building for real
+            // hardware!
 #if REVISION < 0xA
             rfu_waitREQComplete();
 #endif


### PR DESCRIPTION
The removal of rfu_waitREQComplete in revision A is an emulation hack for sloop. Make sure people don't think they can get away with removing it for real hardware!