### PR TITLE
Fix Typo in Cinnabar Gym Label

### DIFF
--- a/data/maps/CinnabarIsland_Gym/map.json
+++ b/data/maps/CinnabarIsland_Gym/map.json
@@ -195,7 +195,7 @@
       "y": 10,
       "elevation": 0,
       "player_facing_dir": "BG_EVENT_PLAYER_FACING_NORTH",
-      "script": "CinnabarIsland_Gym_EventScript_Quz1Left"
+      "script": "CinnabarIsland_Gym_EventScript_Quiz1Left"
     },
     {
       "type": "sign",
@@ -203,7 +203,7 @@
       "y": 10,
       "elevation": 0,
       "player_facing_dir": "BG_EVENT_PLAYER_FACING_NORTH",
-      "script": "CinnabarIsland_Gym_EventScript_Quz1Right"
+      "script": "CinnabarIsland_Gym_EventScript_Quiz1Right"
     },
     {
       "type": "sign",

--- a/data/maps/CinnabarIsland_Gym/scripts.inc
+++ b/data/maps/CinnabarIsland_Gym/scripts.inc
@@ -194,13 +194,13 @@ CinnabarIsland_Gym_EventScript_GymStatuePostVictory::
 	releaseall
 	end
 
-CinnabarIsland_Gym_EventScript_Quz1Left::
+CinnabarIsland_Gym_EventScript_Quiz1Left::
 	lockall
 	setvar VAR_TEMP_1, 0
 	goto CinnabarIsland_Gym_EventScript_Quiz1
 	end
 
-CinnabarIsland_Gym_EventScript_Quz1Right::
+CinnabarIsland_Gym_EventScript_Quiz1Right::
 	lockall
 	setvar VAR_TEMP_1, 1
 	goto CinnabarIsland_Gym_EventScript_Quiz1


### PR DESCRIPTION
`CinnabarIsland_Gym_EventScript_Quz1Left` and `CinnabarIsland_Gym_EventScript_Quz1Right` corrected "Quz" to "Quiz".