### PR TITLE
gbagfx: fix heap overflow when reading half-width Latin fonts

### DIFF
--- a/tools/gbagfx/font.c
+++ b/tools/gbagfx/font.c
@@ -224,7 +224,7 @@ void ReadHalfWidthLatinFont(char *path, struct Image *image)
 	int fileSize;
 	unsigned char *buffer = ReadWholeFile(path, &fileSize);
 
-	int numGlyphs = fileSize / 32;
+	int numGlyphs = fileSize / 64;
 
 	if (numGlyphs % 16 != 0)
 		FATAL_ERROR("The number of glyphs (%d) is not a multiple of 16.\n", numGlyphs);


### PR DESCRIPTION
Fixes a heap-buffer-overflow (corrupted size vs. prev_size) when converting a .hwlatfont binary back to a PNG image using gbagfx.