### PR TITLE
Fix Erroneous LocalId in Mt. Ember

### DIFF
--- a/data/maps/MtEmber_RubyPath_B3F/map.json
+++ b/data/maps/MtEmber_RubyPath_B3F/map.json
@@ -16,7 +16,6 @@
   "connections": null,
   "object_events": [
     {
-      "local_id": "LOCALID_RUBY",
       "type": "object",
       "graphics_id": "OBJ_EVENT_GFX_PUSHABLE_BOULDER",
       "x": 10,

--- a/data/maps/MtEmber_RubyPath_B5F/map.json
+++ b/data/maps/MtEmber_RubyPath_B5F/map.json
@@ -16,6 +16,7 @@
   "connections": null,
   "object_events": [
     {
+      "local_id": "LOCALID_RUBY",
       "type": "object",
       "graphics_id": "OBJ_EVENT_GFX_RUBY",
       "x": 7,


### PR DESCRIPTION
A random pushable boulder in `MtEmber_RubyPath_B3F` was assigned `LOCALID_RUBY`. This is now fixed.